### PR TITLE
feat/hub-page-improvements-for-students-and-instructors

### DIFF
--- a/src/components/components/hub-components/Goals.vue
+++ b/src/components/components/hub-components/Goals.vue
@@ -43,7 +43,7 @@ export default {
 
 <template>
     <h2 class="secondary-heading h4">Goals</h2>
-    <div id="goal-list">
+    <div v-if="goals.length > 0" id="goal-list">
         <div v-for="goal in goals">
             <router-link
                 :class="{
@@ -93,6 +93,7 @@ export default {
 .goal-link {
     text-decoration: none !important;
     color: black;
+    text-align: start;
 }
 
 /* Level colors */

--- a/src/components/components/hub-components/HubStudentQuestionList.vue
+++ b/src/components/components/hub-components/HubStudentQuestionList.vue
@@ -61,9 +61,7 @@ export default {
 </script>
 
 <template>
-    <div class="container-fluid">
         <h2 class="secondary-heading h4">Check New Questions</h2>
-
         <div class="list-body">
             <div class="question" v-for="question in questions">
                 <RouterLink
@@ -78,7 +76,6 @@ export default {
                 </RouterLink>
             </div>
         </div>
-    </div>
 </template>
 
 <style scoped>

--- a/src/components/components/hub-components/LastVisitedSkills.vue
+++ b/src/components/components/hub-components/LastVisitedSkills.vue
@@ -20,7 +20,7 @@ export default {
 
 <template>
     <h2 class="secondary-heading h4">Last visited Skills</h2>
-    <div id="skill-list">
+    <div v-if="visitedSkills.length > 0" id="skill-list">
         <div v-for="skill in visitedSkills">
             <router-link
                 :class="{
@@ -77,6 +77,7 @@ export default {
 .skill-link {
     text-decoration: none !important;
     color: black;
+    text-align: start
 }
 
 /* Level colors */

--- a/src/components/components/hub-components/MarkAssessment.vue
+++ b/src/components/components/hub-components/MarkAssessment.vue
@@ -112,23 +112,21 @@ export default {
 </script>
 
 <template>
-    <div class="container-fluid">
-        <h2 class="secondary-heading h4">Mark Assessments</h2>
-        <div id="list-body">
-            <div class="assessment" v-for="assessment in this.assessments">
-                <RouterLink
-                    class="assessment-link"
-                    :to="'/mark-assessment/' + assessment.id"
-                >
-                    <span id="student-name">
-                        {{ assessment.studentUsername }},
-                    </span>
-                    <span id="skill-name"> {{ assessment.skillName }}, </span>
-                    <span id="date">
-                        {{ assessment.date }}
-                    </span>
-                </RouterLink>
-            </div>
+    <h2 class="secondary-heading h4">Mark Assessments</h2>
+    <div v-if="this.assessments.length > 0" id="list-body">
+        <div class="assessment" v-for="assessment in this.assessments">
+            <RouterLink
+                class="assessment-link"
+                :to="'/mark-assessment/' + assessment.id"
+            >
+                <span id="student-name">
+                    {{ assessment.studentUsername }},
+                </span>
+                <span id="skill-name"> {{ assessment.skillName }}, </span>
+                <span id="date">
+                    {{ assessment.date }}
+                </span>
+            </RouterLink>
         </div>
     </div>
 </template>

--- a/src/components/components/hub-components/StudentProgress.vue
+++ b/src/components/components/hub-components/StudentProgress.vue
@@ -40,7 +40,7 @@ export default {
 
 <template>
     <h2 class="secondary-heading h4">Available Skills</h2>
-    <div id="skill-list">
+    <div v-if="availableSkills.length > 0" id="skill-list">
         <div v-for="availableSkill in availableSkills">
             <router-link
                 :class="{
@@ -98,6 +98,7 @@ export default {
 .skill-link {
     text-decoration: none !important;
     color: black;
+    text-align: start;
 }
 
 /* Level colors */

--- a/src/components/pages/HubView.vue
+++ b/src/components/pages/HubView.vue
@@ -39,6 +39,21 @@ export default {
                 ' ' +
                 this.userDetailsStore.lastName
             );
+        },
+        hasAssessments() {
+            return this.userDetailsStore.assessments && this.userDetailsStore.assessments.length > 0;
+        },
+        hasQuestions() {
+            return this.userDetailsStore.questions && this.userDetailsStore.questions.length > 0;
+        },
+        showFirstContainer() {
+            return this.userDetailsStore.role != 'editor' && (this.userDetailsStore.role == 'student' || this.hasAssessments);
+        },
+        showSecondContainer() {
+            return this.userDetailsStore.role != 'editor' && (this.userDetailsStore.role == 'student' || this.hasQuestions);
+        },
+        showContentRow() {
+            return this.showFirstContainer || this.showSecondContainer;
         }
     },
     methods: {}
@@ -46,12 +61,13 @@ export default {
 </script>
 
 <template>
-    <div class="container min-vh-100">
-        <div class="row content-row">
+    <div class="container min-vh-100 pt-md-5 pt-4">
+        <div class="row content-row gy-2" v-if="showContentRow">
             <!-- Available Skills / Mark Assessments -->
             <div
                 class="col-lg-4 col-md-6 mb-2"
-                v-if="userDetailsStore.role != 'editor'"
+                v-if="showFirstContainer"
+                :style="{ display: showFirstContainer ? 'block' : 'none' }"
             >
                 <div class="hub-component">
                     <StudentProgress
@@ -59,14 +75,15 @@ export default {
                         :userId="userDetailsStore.userId"
                     />
                     <MarkAssessment
-                        v-else-if="userDetailsStore.role == 'instructor'"
+                        v-else-if="userDetailsStore.role == 'instructor' && hasAssessments"
                     />
                 </div>
             </div>
             <!-- Last Visited Skills / Student Suggested Questions -->
             <div
                 class="col-lg-4 col-md-6 mb-2"
-                v-if="userDetailsStore.role != 'editor'"
+                v-if="showSecondContainer"
+                :style="{ display: showSecondContainer ? 'block' : 'none' }"
             >
                 <div class="hub-component">
                     <LastVisitedSkills
@@ -75,7 +92,7 @@ export default {
                     />
                     <!-- Student Added Questions List -->
                     <HubStudentQuestionList
-                        v-else-if="userDetailsStore.role == 'instructor'"
+                        v-else-if="userDetailsStore.role == 'instructor' && hasQuestions"
                     />
                 </div>
             </div>
@@ -88,14 +105,14 @@ export default {
                 </div>
             </div>
         </div>
-        <div class="row">
+        <div class="row mt-4">
             <div class="col-lg-4 col-md-6 mb-2">
                 <div class="hub-component">
                     <Notifications />
                 </div>
             </div>
         </div>
-        <div class="row">
+        <div class="row mt-4">
             <div class="col">
                 <div class="hub-component">
                     <News />


### PR DESCRIPTION
Even tho I used the name for the PR as student. I've made sure both tasks are completed within this. The first issue within the first task was simply due to the aspect that the logo wasn't loading In. That resolved the height issue. I've adjusted the styling a bit by adding some margins to make some distance between the content and the menu. Additionally, for that I've also added some gaps between the first row of components for the mobile screen.

When it comes to the Instructor improvements I've created **`hasAssessments`**, `**hasQuestions**` to check whether or not there is any data within the store, and depending If there isn't any the components do not show up for instructors. Now since there was also an issue when if the components didn't render, the main div container still hold up space within the DOM. So I've created **`showFirstContainer`**, **`showSecondContainer`**  and **`showContentRow`**. Where with the showContainers we check if any component renders even If they're empty, in our case let's take  StudentProgress as an example. It will still render even If It's empty. Now for the showContentRow, it is to ensure that if there isn't anything, the main container does not take up any space within the DOM.