### PR TITLE
fix/new-student-question-bug-changed-to-instructor

### DIFF
--- a/src/components/pages/CheckStudentQuestionView.vue
+++ b/src/components/pages/CheckStudentQuestionView.vue
@@ -313,7 +313,7 @@ export default {
                     <div
                         v-if="
                             userDetailsStore.role == 'admin' ||
-                            userDetailsStore.role == 'editor'
+                            userDetailsStore.role == 'instructor'
                         "
                         class="d-flex justify-content-end gap-4"
                     >


### PR DESCRIPTION
Resolved the issue, the buttons should appear now. It seems ti was set to show up on only editor/admin, while we access it as an instructor.