### PR TITLE
fix-skills-view-tablet-adjusted-margin-added-gap

### DIFF
--- a/src/components/pages/SkillsView.vue
+++ b/src/components/pages/SkillsView.vue
@@ -207,13 +207,13 @@ export default {
                         v-if="
                             !instructorMode && userDetailsStore.role != 'admin'
                         "
-                        class="col d-flex align-items-center"
+                        class="col d-flex align-items-center justify-content-center"
                     >
-                        <div class="d-flex">
+                        <div class="d-flex w-100 justify-content-md-between gap-3 custom-grade-buttons">
                             <button
                                 v-for="grade in gradeLevels"
                                 :key="grade.level"
-                                class="btn me-2 w-100"
+                                class="btn w-100"
                                 :class="{
                                     'primary-btn': true,
                                     'active-grade-filter':
@@ -728,6 +728,10 @@ export default {
     margin: 2px;
     border-radius: 50%;
 }
+.custom-grade-buttons .primary-btn {
+        width: 100% !important;
+        max-width: unset !important;
+    }
 
 /* Small devices (portrait phones) */
 @media (max-width: 480px) {


### PR DESCRIPTION
In this PR I've adjusted instead of me-2 to have a gap-3, and I've added a custom-grade-buttons class to target the primary-btn class from bootstrap without altering the styling of the others who use the same one, this way we ensure the styling doesn't break.