### PR TITLE
fix/subskills-not-showing-resolved-adjusted-link-alignment-on-skill-panel

### DIFF
--- a/src/components/components/SkillPanel.vue
+++ b/src/components/components/SkillPanel.vue
@@ -228,6 +228,7 @@ img {
 
 .list-container a {
     text-decoration: none;
+    text-align: start;
 }
 
 /* Slide left animation */

--- a/src/components/components/skilltrees/TidyTree.vue
+++ b/src/components/components/skilltrees/TidyTree.vue
@@ -35,7 +35,8 @@ export default {
                 tagIDs: [],
                 sprite: null,
                 type: null,
-                hasChildren: false
+                hasChildren: false,
+                subskills: []
             },
             tree: {},
             root: {},
@@ -176,6 +177,14 @@ export default {
                     '/skills/mastery-requirements-and-url/' + this.skill.id
                 );
                 const result2 = await result.json();
+                if (this.skill.type == 'super') {
+                    // Get urls of subskills, if a super skill
+                    const subSkillsResult = await fetch(
+                        '/skills/sub-skills/' + this.skill.id
+                    );
+                    const subSkillsResultJson = await subSkillsResult.json();
+                    this.skill.subskills = subSkillsResultJson;
+                }
                 this.skill.masteryRequirements = result2.mastery_requirements;
                 this.skill.url = result2.url;
                 this.showSkillPanel = true;


### PR DESCRIPTION
In this PR I've added the request we had from the radial tree to the tidy tree, the subskills will show up now. I've also adjusted a small text alignment issue that shows up on a desktop screen, so the subskill links should look the same across all devices.