### PR TITLE
feat/adjusted-the-spinner-animation-to-show-in-the-center-of-the-screen

### DIFF
--- a/src/components/components/AddStudent.vue
+++ b/src/components/components/AddStudent.vue
@@ -592,15 +592,13 @@ export default {
     }
 }
 
-@media screen and (min-width: 992px) {
-    .loading-animation {
-        min-height: 100%;
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        -webkit-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%);
-    }
+.loading-animation {
+    min-height: 100%;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
 }
 /* End of loading animation */
 

--- a/src/components/components/SkillsListParent.vue
+++ b/src/components/components/SkillsListParent.vue
@@ -331,16 +331,13 @@ export default {
         transform: rotate(360deg);
     }
 }
-
-@media screen and (min-width: 992px) {
-    /* Loading animation */
-    .loading-animation {
-        min-height: 100%;
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        -webkit-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%);
-    }
+/* Loading animation */
+.loading-animation {
+    min-height: 100%;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
 }
 </style>

--- a/src/components/components/assessments/Assessment.vue
+++ b/src/components/components/assessments/Assessment.vue
@@ -1244,6 +1244,16 @@ export default {
         transform: rotate(360deg);
     }
 }
+
+/* Loading animation */
+.loading-animation {
+    min-height: 100%;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
+}
 /******************************/
 /* Mobile Styling */
 @media (max-width: 480px) {

--- a/src/components/components/skilltrees/LearningTrack.vue
+++ b/src/components/components/skilltrees/LearningTrack.vue
@@ -1050,16 +1050,13 @@ canvas {
         height: calc(100%);
     }
 }
-
-@media screen and (min-width: 992px) {
-    /* Loading animation */
-    .loading-animation {
-        min-height: 100%;
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        -webkit-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%);
-    }
+/* Loading animation */
+.loading-animation {
+    min-height: 100%;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
 }
 </style>

--- a/src/components/components/skilltrees/RadialTree.vue
+++ b/src/components/components/skilltrees/RadialTree.vue
@@ -1054,15 +1054,13 @@ canvas {
     }
 }
 
-@media screen and (min-width: 992px) {
-    /* Loading animation */
-    .loading-animation {
-        min-height: 100%;
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        -webkit-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%);
-    }
+/* Loading animation */
+.loading-animation {
+    min-height: 100%;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
 }
 </style>

--- a/src/components/components/skilltrees/StudentTidyTree.vue
+++ b/src/components/components/skilltrees/StudentTidyTree.vue
@@ -925,16 +925,13 @@ input[type='button'] {
         flex-direction: column;
     }
 }
-
-@media screen and (min-width: 992px) {
-    /* Loading animation */
-    .loading-animation {
-        min-height: 100%;
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        -webkit-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%);
-    }
+/* Loading animation */
+.loading-animation {
+    min-height: 100%;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
 }
 </style>

--- a/src/components/components/skilltrees/TidyTree.vue
+++ b/src/components/components/skilltrees/TidyTree.vue
@@ -1550,6 +1550,16 @@ export default {
 </template>
 
 <style scoped>
+/* Loading animation */
+.loading-animation {
+    min-height: 100%;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
+}
+
 .loader {
     width: 48px;
     height: 48px;
@@ -1692,18 +1702,6 @@ canvas {
     #wrapper {
         /* height: calc(100% - 130px); */
         height: calc(100%);
-    }
-}
-
-@media screen and (min-width: 992px) {
-    /* Loading animation */
-    .loading-animation {
-        min-height: 100%;
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        -webkit-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%);
     }
 }
 </style>

--- a/src/components/components/skilltrees/TidyTreeNoAccount.vue
+++ b/src/components/components/skilltrees/TidyTreeNoAccount.vue
@@ -994,15 +994,13 @@ canvas {
     }
 }
 
-@media screen and (min-width: 992px) {
-    /* Loading animation */
-    .loading-animation {
-        min-height: 100%;
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        -webkit-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%);
-    }
+/* Loading animation */
+.loading-animation {
+    min-height: 100%;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
 }
 </style>

--- a/src/components/pages/cohorts/CohortView.vue
+++ b/src/components/pages/cohorts/CohortView.vue
@@ -295,16 +295,14 @@ export default {
     }
 }
 
-@media screen and (min-width: 992px) {
-    /* Loading animation */
-    .loading-animation {
-        min-height: 100%;
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        -webkit-transform: translate(-50%, -50%);
-        transform: translate(-50%, -50%);
-    }
+/* Loading animation */
+.loading-animation {
+    min-height: 100%;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
 }
 /* End of loading animation */
 


### PR DESCRIPTION
In this PR I've adjusted the fix for the center of the spinner. The issue was that the **`"loading-animation"`** class was only active for screens above a tablet, hence why for mobile and tablet It showed up above. There are certain components that don't have this class In them. I'm unsure if we should add It to these components or not. (Example, in **`StudentQuestionList.vue`**)