### PR TITLE
feat/profile-button-improvements-2&3

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -305,6 +305,12 @@ export default {
                                     >
                                         Profile
                                     </RouterLink>
+                                    <RouterLink
+                                        to="/profile"
+                                        class="dropdown-item"
+                                    >
+                                        Settings
+                                    </RouterLink>
                                     <div class="dropdown-divider"></div>
                                     <a
                                         v-if="sessionDetailsStore.isLoggedIn"

--- a/src/components/components/profile-page/ProfileDetails.vue
+++ b/src/components/components/profile-page/ProfileDetails.vue
@@ -168,16 +168,6 @@ export default {
                         readonly
                     />
                 </div>
-                <!-- Instructor -->
-                <div v-if="userDetailsStore.instructorUsername" class="mb-3">
-                    <h2 class="secondary-heading h4">Instructor</h2>
-                    <input
-                        type="text"
-                        class="form-control"
-                        readonly
-                        :value="userDetailsStore.instructorUsername"
-                    />
-                </div>
             </div>
         </div>
     </div>

--- a/src/components/components/profile-page/ThemeDetails.vue
+++ b/src/components/components/profile-page/ThemeDetails.vue
@@ -26,7 +26,7 @@ export default {
 </script>
 
 <template>
-    <div class="container pb-4 theme-background mt-2">
+    <div>
         <h2 class="secondary-heading h4">Theme</h2>
         <!-- Choose theme -->
         <div class="mb-3 text-start themes">

--- a/src/components/pages/NewProfileSettings.vue
+++ b/src/components/pages/NewProfileSettings.vue
@@ -1,0 +1,73 @@
+<script lang="ts">
+import ThemeDetails from '../components/profile-page/ThemeDetails.vue';
+import { useUserDetailsStore } from '../../stores/UserDetailsStore';
+import { useSessionDetailsStore } from '../../stores/SessionDetailsStore.js';
+
+export default {
+    setup() {
+        const userDetailsStore = useUserDetailsStore();
+        const sessionDetailsStore = useSessionDetailsStore();
+        userDetailsStore.getUserDetails();
+        return {
+            userDetailsStore,
+            sessionDetailsStore
+        };
+    },
+    data() {
+        return {};
+    },
+    components: {
+        ThemeDetails
+    },
+    methods: {}
+};
+</script>
+
+<template>
+    <div class="container legend-div">
+        <div class="mt-2 d-flex gap-2 justify-content-between">
+            <ThemeDetails />
+            <div class="form">
+                <div>
+                    <!-- Instructor -->
+                    <div
+                        v-if="userDetailsStore.instructorUsername"
+                        class="profile-input"
+                    >
+                        <h2 class="secondary-heading h4">Instructor</h2>
+                        <input
+                            type="text"
+                            class="form-control"
+                            readonly
+                            :value="userDetailsStore.instructorUsername"
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.legend-div {
+    width: 100%;
+    z-index: 2;
+    top: 80px;
+}
+
+.profile-input {
+    width: '100%';
+    max-width: 300px;
+}
+.form-control {
+    border: 1px solid #f2f4f7;
+    box-shadow: 0px 1px 2px 0px #1018280d;
+    font-family: 'Poppins' sans-serif;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 22px;
+    letter-spacing: 0.03em;
+    text-align: left;
+    color: black;
+}
+</style>

--- a/src/components/pages/ProfileSettingsView.vue
+++ b/src/components/pages/ProfileSettingsView.vue
@@ -1,6 +1,5 @@
 <script>
 import ProfileDetails from '../components/profile-page/ProfileDetails.vue';
-import ThemeDetails from '../components/profile-page/ThemeDetails.vue';
 import ReputationDetails from '../components/profile-page/ReputationDetails.vue';
 import Settings from '../components/settings/Settings.vue';
 import BulkQuestionsUpload from '../components/settings/BulkQuestionsUpload.vue';
@@ -25,7 +24,6 @@ export default {
     },
     components: {
         ProfileDetails,
-        ThemeDetails,
         ReputationDetails,
         Settings,
         BulkQuestionsUpload,
@@ -63,7 +61,6 @@ export default {
                 </div>
             </div>
         </div>
-        <ThemeDetails />
         <div class="container pb-4 theme-background mt-2">
             <h2 class="secondary-heading h4">Reputation</h2>
             <ReputationDetails />

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -256,6 +256,12 @@ const router = createRouter({
                 import('../components/pages/ProfileSettingsView.vue')
         },
         {
+            path: '/profile',
+            name: 'profile',
+            component: () =>
+                import('../components/pages/NewProfileSettings.vue')
+        },
+        {
             path: '/profile/edit',
             name: 'edit-profile',
             component: () => import('../components/pages/EditProfileView.vue')


### PR DESCRIPTION
In this PR I've finished both the 2nd and 3rd one. Since both just required to add In singular fields. The name can currently sit as a placeholder as **`NewProfileSettings.vue`** , as there is one already called **`PorfileSettingsView.vue`**. I've also added the route as **`/profile`** , also a placeholder for now, as we have a **`/profile-settings`** one. I also think we need to think about what to add to these pages, as they're a bit too empty for the time being.