### PR TITLE
feat/added-new-page-to-allow-instructors-to-edit-student-passwords

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -940,6 +940,32 @@ router.put(
 );
 
 // User update their password from profile page
+router.put('/profile/:id/edit-password', isAuthenticated, (req, res, next) => {
+    // Hash the password.
+    bcrypt.hash(req.body.password, saltRounds, function (err, hashedPassword) {
+        if (err) {
+            console.log(err);
+        }
+
+        // Add data.
+        let sqlQuery = `UPDATE users 
+                    SET password = ${conn.escape(hashedPassword)} 
+                    WHERE id = ${conn.escape(req.params.id)};`;
+
+        conn.query(sqlQuery, (err, results) => {
+            try {
+                if (err) {
+                    throw err;
+                }
+                res.end();
+            } catch (err) {
+                next(err);
+            }
+        });
+    });
+});
+
+// Allow instructor to edit student password
 router.put(
     '/:studentId/edit-student-password',
     isAuthenticated,

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -941,9 +941,8 @@ router.put(
 
 // User update their password from profile page
 router.put(
-    '/profile/:id/edit-password',
+    '/:studentId/edit-student-password',
     isAuthenticated,
-    editSelfPermission,
     (req, res, next) => {
         // Hash the password.
         bcrypt.hash(
@@ -957,7 +956,7 @@ router.put(
                 // Add data.
                 let sqlQuery = `UPDATE users 
                     SET password = ${conn.escape(hashedPassword)} 
-                    WHERE id = ${conn.escape(req.params.id)};`;
+                    WHERE id = ${conn.escape(req.params.studentId)};`;
 
                 conn.query(sqlQuery, (err, results) => {
                     try {

--- a/src/components/components/EditProfile.vue
+++ b/src/components/components/EditProfile.vue
@@ -6,8 +6,6 @@ import { useUsersStore } from '../../stores/UsersStore';
 import { Cropper, Preview } from 'vue-advanced-cropper';
 import 'vue-advanced-cropper/dist/style.css';
 import 'vue-advanced-cropper/dist/theme.compact.css';
-// others component import
-import CheckPasswordComplexity from './CheckPasswordComplexity.vue';
 
 export default {
     setup() {
@@ -62,8 +60,7 @@ export default {
     },
     components: {
         Cropper,
-        Preview,
-        CheckPasswordComplexity
+        Preview
     },
     computed: {},
     methods: {
@@ -75,11 +72,6 @@ export default {
             }
             this.Submit();
         },
-        ValidatePassword() {
-            if (this.validate.passwordComplex) {
-                this.HandlePasswordUpdate();
-            }
-        },
         ValidateEmail() {
             if (
                 /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(this.email)
@@ -88,21 +80,6 @@ export default {
             } else {
                 this.validate.emailFormat = true;
             }
-        },
-        HandlePasswordUpdate() {
-            const requestOptions = {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    password: this.password
-                })
-            };
-
-            var url = '/users/profile/' + this.id + '/edit-password';
-            fetch(url, requestOptions).then(() => {
-                this.userDetailsStore.getUserDetails();
-                this.$router.push('/profile');
-            });
         },
         Submit() {
             // If valid, submit.
@@ -459,84 +436,6 @@ export default {
                         Submit
                     </button>
                 </div>
-
-                <hr class="mt-5 mb-5" />
-                <!-- Password Section -->
-                <h2 class="secondary-heading h4">Update Password</h2>
-                <div class="mb-3">
-                    <div class="password-div">
-                        <input
-                            v-model="password"
-                            :type="passwordVisible ? 'text' : 'password'"
-                            placeholder="Password"
-                            class="form-control"
-                            id="password-input"
-                            required
-                        />
-                        <!-- Show and Hide Password Section -->
-                        <div
-                            class="eye-icon"
-                            b-tooltip.hover
-                            :title="
-                                passwordVisible
-                                    ? 'hide password'
-                                    : 'show password'
-                            "
-                        >
-                            <!-- Eye Icon -->
-                            <svg
-                                v-if="passwordVisible"
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 576 512"
-                                width="20"
-                                height="20"
-                                fill="gray"
-                                @click="passwordVisible = false"
-                            >
-                                <path
-                                    d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                                />
-                            </svg>
-                            <!-- Eye Slash Icon -->
-                            <svg
-                                v-else
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 640 512"
-                                width="20"
-                                height="20"
-                                fill="gray"
-                                @click="passwordVisible = true"
-                            >
-                                <path
-                                    d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4c3.3-7.9 3.3-16.7 0-24.6c-14.9-35.7-46.2-87.7-93-131.1C465.5 68.8 400.8 32 320 32c-68.2 0-125 26.3-169.3 60.8L38.8 5.1zm151 118.3C226 97.7 269.5 80 320 80c65.2 0 118.8 29.6 159.9 67.7C518.4 183.5 545 226 558.6 256c-12.6 28-36.6 66.8-70.9 100.9l-53.8-42.2c9.1-17.6 14.2-37.5 14.2-58.7c0-70.7-57.3-128-128-128c-32.2 0-61.7 11.9-84.2 31.5l-46.1-36.1zM394.9 284.2l-81.5-63.9c4.2-8.5 6.6-18.2 6.6-28.3c0-5.5-.7-10.9-2-16c.7 0 1.3 0 2 0c44.2 0 80 35.8 80 80c0 9.9-1.8 19.4-5.1 28.2zm51.3 163.3l-41.9-33C378.8 425.4 350.7 432 320 432c-65.2 0-118.8-29.6-159.9-67.7C121.6 328.5 95 286 81.4 256c8.3-18.4 21.5-41.5 39.4-64.8L83.1 161.5C60.3 191.2 44 220.8 34.5 243.7c-3.3 7.9-3.3 16.7 0 24.6c14.9 35.7 46.2 87.7 93 131.1C174.5 443.2 239.2 480 320 480c47.8 0 89.9-12.9 126.2-32.5zm-88-69.3L302 334c-23.5-5.4-43.1-21.2-53.7-42.3l-56.1-44.2c-.2 2.8-.3 5.6-.3 8.5c0 70.7 57.3 128 128 128c13.3 0 26.1-2 38.2-5.8z"
-                                />
-                            </svg>
-                        </div>
-                    </div>
-                    <div
-                        v-if="
-                            validate.password &&
-                            (password == '' || password == null)
-                        "
-                        class="form-validate"
-                    >
-                        please enter a password!
-                    </div>
-                    <CheckPasswordComplexity
-                        :formData="{
-                            username: userName,
-                            password: password,
-                            firstName: firstName,
-                            lastName: lastName,
-                            email: email
-                        }"
-                    />
-                </div>
-                <div class="d-flex justify-content-between mb-3 mt-2">
-                    <button class="btn primary-btn" @click="ValidatePassword()">
-                        Update
-                    </button>
-                </div>
             </div>
         </div>
 
@@ -693,22 +592,6 @@ export default {
 
 #img-background {
     border-radius: 12px;
-}
-
-.password-div {
-    position: relative;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-}
-
-.eye-icon {
-    position: absolute;
-    right: 20px;
-}
-
-.eye-icon:hover {
-    cursor: pointer;
 }
 
 .form-control {

--- a/src/components/components/EditProfile.vue
+++ b/src/components/components/EditProfile.vue
@@ -6,6 +6,8 @@ import { useUsersStore } from '../../stores/UsersStore';
 import { Cropper, Preview } from 'vue-advanced-cropper';
 import 'vue-advanced-cropper/dist/style.css';
 import 'vue-advanced-cropper/dist/theme.compact.css';
+// others component import
+import CheckPasswordComplexity from './CheckPasswordComplexity.vue';
 
 export default {
     setup() {
@@ -60,7 +62,8 @@ export default {
     },
     components: {
         Cropper,
-        Preview
+        Preview,
+        CheckPasswordComplexity
     },
     computed: {},
     methods: {
@@ -72,6 +75,11 @@ export default {
             }
             this.Submit();
         },
+        ValidatePassword() {
+            if (this.validate.passwordComplex) {
+                this.HandlePasswordUpdate();
+            }
+        },
         ValidateEmail() {
             if (
                 /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(this.email)
@@ -80,6 +88,20 @@ export default {
             } else {
                 this.validate.emailFormat = true;
             }
+        },
+        HandlePasswordUpdate() {
+            const requestOptions = {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    password: this.password
+                })
+            };
+            var url = '/users/profile/' + this.id + '/edit-password';
+            fetch(url, requestOptions).then(() => {
+                this.userDetailsStore.getUserDetails();
+                this.$router.push('/profile');
+            });
         },
         Submit() {
             // If valid, submit.
@@ -436,6 +458,83 @@ export default {
                         Submit
                     </button>
                 </div>
+                <hr class="mt-5 mb-5" />
+                <!-- Password Section -->
+                <h2 class="secondary-heading h4">Update Password</h2>
+                <div class="mb-3">
+                    <div class="password-div">
+                        <input
+                            v-model="password"
+                            :type="passwordVisible ? 'text' : 'password'"
+                            placeholder="Password"
+                            class="form-control"
+                            id="password-input"
+                            required
+                        />
+                        <!-- Show and Hide Password Section -->
+                        <div
+                            class="eye-icon"
+                            b-tooltip.hover
+                            :title="
+                                passwordVisible
+                                    ? 'hide password'
+                                    : 'show password'
+                            "
+                        >
+                            <!-- Eye Icon -->
+                            <svg
+                                v-if="passwordVisible"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 576 512"
+                                width="20"
+                                height="20"
+                                fill="gray"
+                                @click="passwordVisible = false"
+                            >
+                                <path
+                                    d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
+                                />
+                            </svg>
+                            <!-- Eye Slash Icon -->
+                            <svg
+                                v-else
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 640 512"
+                                width="20"
+                                height="20"
+                                fill="gray"
+                                @click="passwordVisible = true"
+                            >
+                                <path
+                                    d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4c3.3-7.9 3.3-16.7 0-24.6c-14.9-35.7-46.2-87.7-93-131.1C465.5 68.8 400.8 32 320 32c-68.2 0-125 26.3-169.3 60.8L38.8 5.1zm151 118.3C226 97.7 269.5 80 320 80c65.2 0 118.8 29.6 159.9 67.7C518.4 183.5 545 226 558.6 256c-12.6 28-36.6 66.8-70.9 100.9l-53.8-42.2c9.1-17.6 14.2-37.5 14.2-58.7c0-70.7-57.3-128-128-128c-32.2 0-61.7 11.9-84.2 31.5l-46.1-36.1zM394.9 284.2l-81.5-63.9c4.2-8.5 6.6-18.2 6.6-28.3c0-5.5-.7-10.9-2-16c.7 0 1.3 0 2 0c44.2 0 80 35.8 80 80c0 9.9-1.8 19.4-5.1 28.2zm51.3 163.3l-41.9-33C378.8 425.4 350.7 432 320 432c-65.2 0-118.8-29.6-159.9-67.7C121.6 328.5 95 286 81.4 256c8.3-18.4 21.5-41.5 39.4-64.8L83.1 161.5C60.3 191.2 44 220.8 34.5 243.7c-3.3 7.9-3.3 16.7 0 24.6c14.9 35.7 46.2 87.7 93 131.1C174.5 443.2 239.2 480 320 480c47.8 0 89.9-12.9 126.2-32.5zm-88-69.3L302 334c-23.5-5.4-43.1-21.2-53.7-42.3l-56.1-44.2c-.2 2.8-.3 5.6-.3 8.5c0 70.7 57.3 128 128 128c13.3 0 26.1-2 38.2-5.8z"
+                                />
+                            </svg>
+                        </div>
+                    </div>
+                    <div
+                        v-if="
+                            validate.password &&
+                            (password == '' || password == null)
+                        "
+                        class="form-validate"
+                    >
+                        please enter a password!
+                    </div>
+                    <CheckPasswordComplexity
+                        :formData="{
+                            username: userName,
+                            password: password,
+                            firstName: firstName,
+                            lastName: lastName,
+                            email: email
+                        }"
+                    />
+                </div>
+                <div class="d-flex justify-content-between mb-3 mt-2">
+                    <button class="btn primary-btn" @click="ValidatePassword()">
+                        Update
+                    </button>
+                </div>
             </div>
         </div>
 
@@ -592,6 +691,19 @@ export default {
 
 #img-background {
     border-radius: 12px;
+}
+.password-div {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+.eye-icon {
+    position: absolute;
+    right: 20px;
+}
+.eye-icon:hover {
+    cursor: pointer;
 }
 
 .form-control {

--- a/src/components/components/UserDetails.vue
+++ b/src/components/components/UserDetails.vue
@@ -28,7 +28,7 @@ export default {
 
     methods: {
         updateSkillsLock() {
-            this.$parent.updateSkillsLock()
+            this.$parent.updateSkillsLock();
         }
     }
 };
@@ -251,6 +251,17 @@ export default {
                         v-model="this.$parent.instructor"
                         disabled
                     />
+                </div>
+                <div
+                    v-if="userDetailsStore.role == 'instructor'"
+                    class="d-flex justify-content-start mt-3"
+                >
+                    <router-link
+                        :to="'/edit-student-password/' + this.$parent.user.id"
+                        class="btn primary-btn"
+                    >
+                        Change password
+                    </router-link>
                 </div>
             </div>
         </div>

--- a/src/components/pages/ChangeStudentPasswordView.vue
+++ b/src/components/pages/ChangeStudentPasswordView.vue
@@ -1,0 +1,156 @@
+<script lang="ts">
+import { useUserDetailsStore } from '../../stores/UserDetailsStore';
+import { useUsersStore } from '../../stores/UsersStore';
+import CheckPasswordComplexity from '../components/CheckPasswordComplexity.vue';
+export default {
+    setup() {
+        const userDetailsStore = useUserDetailsStore();
+        return {
+            userDetailsStore
+        };
+    },
+    data() {
+        return {
+            userId: this.$route.params.id,
+            password: this.userDetailsStore.password,
+            passwordVisible: false,
+            validate: {
+                password: false
+            }
+        };
+    },
+    components: {
+        CheckPasswordComplexity
+    },
+    methods: {
+        ValidatePassword() {
+            if (this.validate.passwordComplex) {
+                this.HandlePasswordUpdate();
+            }
+        },
+        HandlePasswordUpdate() {
+            const requestOptions = {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    password: this.password
+                })
+            };
+
+            var url = '/users/' + this.userId + '/edit-student-password';
+            fetch(url, requestOptions).then(() => {
+                this.userDetailsStore.getUserDetails();
+                this.$router.push('/students');
+            });
+        }
+    }
+};
+</script>
+
+<template>
+    <div class="container d-flex row mt-3">
+        <!-- Password Section -->
+        <h2 class="secondary-heading h4">Update Password</h2>
+        <div class="mb-3">
+            <div class="password-div">
+                <input
+                    v-model="password"
+                    :type="passwordVisible ? 'text' : 'password'"
+                    placeholder="Password"
+                    class="form-control"
+                    id="password-input"
+                    required
+                />
+                <!-- Show and Hide Password Section -->
+                <div
+                    class="eye-icon"
+                    b-tooltip.hover
+                    :title="passwordVisible ? 'hide password' : 'show password'"
+                >
+                    <!-- Eye Icon -->
+                    <svg
+                        v-if="passwordVisible"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 576 512"
+                        width="20"
+                        height="20"
+                        fill="gray"
+                        @click="passwordVisible = false"
+                    >
+                        <path
+                            d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
+                        />
+                    </svg>
+                    <!-- Eye Slash Icon -->
+                    <svg
+                        v-else
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 640 512"
+                        width="20"
+                        height="20"
+                        fill="gray"
+                        @click="passwordVisible = true"
+                    >
+                        <path
+                            d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4c3.3-7.9 3.3-16.7 0-24.6c-14.9-35.7-46.2-87.7-93-131.1C465.5 68.8 400.8 32 320 32c-68.2 0-125 26.3-169.3 60.8L38.8 5.1zm151 118.3C226 97.7 269.5 80 320 80c65.2 0 118.8 29.6 159.9 67.7C518.4 183.5 545 226 558.6 256c-12.6 28-36.6 66.8-70.9 100.9l-53.8-42.2c9.1-17.6 14.2-37.5 14.2-58.7c0-70.7-57.3-128-128-128c-32.2 0-61.7 11.9-84.2 31.5l-46.1-36.1zM394.9 284.2l-81.5-63.9c4.2-8.5 6.6-18.2 6.6-28.3c0-5.5-.7-10.9-2-16c.7 0 1.3 0 2 0c44.2 0 80 35.8 80 80c0 9.9-1.8 19.4-5.1 28.2zm51.3 163.3l-41.9-33C378.8 425.4 350.7 432 320 432c-65.2 0-118.8-29.6-159.9-67.7C121.6 328.5 95 286 81.4 256c8.3-18.4 21.5-41.5 39.4-64.8L83.1 161.5C60.3 191.2 44 220.8 34.5 243.7c-3.3 7.9-3.3 16.7 0 24.6c14.9 35.7 46.2 87.7 93 131.1C174.5 443.2 239.2 480 320 480c47.8 0 89.9-12.9 126.2-32.5zm-88-69.3L302 334c-23.5-5.4-43.1-21.2-53.7-42.3l-56.1-44.2c-.2 2.8-.3 5.6-.3 8.5c0 70.7 57.3 128 128 128c13.3 0 26.1-2 38.2-5.8z"
+                        />
+                    </svg>
+                </div>
+            </div>
+            <div
+                v-if="validate.password && (password == '' || password == null)"
+                class="form-validate"
+            >
+                please enter a password!
+            </div>
+            <CheckPasswordComplexity
+                :formData="{
+                    password: password
+                }"
+            />
+        </div>
+        <div class="d-flex justify-content-between mb-3 mt-2">
+            <router-link class="btn red-btn" to="/students"
+                >Cancel
+            </router-link>
+            <button class="btn primary-btn" @click="ValidatePassword()">
+                Update
+            </button>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.password-div {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.eye-icon {
+    position: absolute;
+    right: 20px;
+}
+
+.eye-icon:hover {
+    cursor: pointer;
+}
+.form-control {
+    border: 1px solid #f2f4f7;
+    box-shadow: 0px 1px 2px 0px #1018280d;
+    font-family: 'Poppins' sans-serif;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 22px;
+    letter-spacing: 0.03em;
+    text-align: left;
+    color: black;
+}
+
+.form-validate {
+    font-size: 0.75rem;
+    color: red;
+    font-weight: 300;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -303,6 +303,13 @@ const router = createRouter({
                 )
         },
         {
+            path: '/edit-student-password/:id',
+            name: 'edit-student-password',
+            component: () =>
+                import('../components/pages/ChangeStudentPasswordView.vue'),
+            meta: { requiresAuth: true, roles: ['instructor'] }
+        },
+        {
             path: '/reputation',
             name: 'reputation',
             component: () =>


### PR DESCRIPTION
In this PR I've adjusted the backend route name from **`'/profile/:id/edit-password'`** to **`'/:studentId/edit-student-password/'`**, and removed the old code for the password resetting from the **`EditProfile.vue`** to a all new **`ChangeStudentPasswordView.vue`** . I've also double tested the functionality of the route with dummy data I've implemented locally. If there are further adjustments or changes, let me know.