### PR TITLE
Feat/give tutorial tooltips arrows

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -672,4 +672,178 @@ p {
     cursor: not-allowed !important;
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.2) !important;
 }
+
+
+/* Tooltip Arrow (Base) */
+.tooltip-arrow {
+    content: '';
+    position: absolute;
+    width: 0;
+    height: 0;
+}
+.tool-tip-base {
+    position: relative;
+    top: 12px;
+    z-index: 100;
+}
+
+.explain-tool-tip {
+    position: relative;
+    border: var(--primary-color) 1px solid;
+    border-radius: 5px;
+    background-color: white;
+    padding: 5px 10px;
+}
+
+.triangle-top-left:before {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-bottom: 10px solid var(--primary-color);
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    left: 15px;
+    top: -10px;
+}
+
+.triangle-top-left::after {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-bottom: 10px solid white;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    left: 15px;
+    top: -9px;
+}
+/* Tooltip Arrow - Top Middle */
+.triangle-top-middle::before {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-bottom: 10px solid var(--primary-color);
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    left: 50%;
+    transform: translateX(-50%);
+    top: -10px;
+}
+
+.triangle-top-middle::after {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-bottom: 10px solid white;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    left: 50%;
+    transform: translateX(-50%);
+    top: -9px;
+}
+
+/* Tooltip Arrow - Top Right */
+.triangle-top-right::before {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-bottom: 10px solid var(--primary-color);
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    right: 15px;
+    top: -10px;
+}
+
+.triangle-top-right::after {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-bottom: 10px solid white;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    right: 15px;
+    top: -9px;
+}
+
+/* Tooltip Arrow - Bottom Left */
+.triangle-bottom-left::before {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-top: 10px solid var(--primary-color);
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    left: 15px;
+    bottom: -10px;
+}
+
+.triangle-bottom-left::after {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-top: 10px solid white;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    left: 15px;
+    bottom: -9px;
+}
+
+/* Tooltip Arrow - Bottom Middle */
+.triangle-bottom-middle::before {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-top: 10px solid var(--primary-color);
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: -10px;
+}
+
+.triangle-bottom-middle::after {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-top: 10px solid white;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: -9px;
+}
+
+/* Tooltip Arrow - Bottom Right */
+.triangle-bottom-right::before {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-top: 10px solid var(--primary-color);
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    right: 15px;
+    bottom: -10px;
+}
+
+.triangle-bottom-right::after {
+    content: '';
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    border-top: 10px solid white;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    right: 15px;
+    bottom: -9px;
+}
 </style>

--- a/src/components/pages/HubView.vue
+++ b/src/components/pages/HubView.vue
@@ -174,15 +174,23 @@ export default {
                     v-if="
                         showTutorialTip2 && userDetailsStore.role == 'student'
                     "
-                    class="info-panel bg-light rounded p-2 mt-2"
+                    class="tool-tip-base"
+                    :style="{ maxWidth: '300px' }"
                 >
-                    <p>Type a career or skill here to get recommendations.</p>
-                    <button
-                        class="btn primary-btn"
-                        @click="progressTutorial(2)"
-                    >
-                        next
-                    </button>
+                    <div class="explain-tool-tip triangle-top-left">
+                        <div class="tool-tip-text">
+                            <p>
+                                Type a career or skill here to get
+                                recommendations.
+                            </p>
+                            <button
+                                class="btn primary-btn"
+                                @click="progressTutorial(2)"
+                            >
+                                next
+                            </button>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -199,18 +207,22 @@ export default {
                             showTutorialTip3 &&
                             userDetailsStore.role == 'student'
                         "
-                        class="info-panel bg-light rounded p-2 mb-2"
+                        class="tool-tip-base mb-3"
                     >
-                        <p>
-                            This section shows your the last 5 skill pages you
-                            visited.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(3)"
-                        >
-                            next
-                        </button>
+                        <div class="explain-tool-tip triangle-bottom-left">
+                            <div class="tool-tip-text">
+                                <p>
+                                    This section shows your the last 5 skill
+                                    pages you visited.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(3)"
+                                >
+                                    next
+                                </button>
+                            </div>
+                        </div>
                     </div>
                     <LastVisitedSkills
                         v-if="userDetailsStore.role == 'student'"
@@ -230,19 +242,27 @@ export default {
                             showTutorialTip4 &&
                             userDetailsStore.role == 'student'
                         "
-                        class="info-panel bg-light rounded p-2 mb-2"
+                        class="tool-tip-base mb-3"
                     >
-                        <p>This section shows any goals you might have made.</p>
-                        <p>
-                            You can make a goal when there is a skill you want
-                            to master but it is not unlocked yet.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(4)"
-                        >
-                            close
-                        </button>
+                        <div class="explain-tool-tip triangle-bottom-left">
+                            <div class="tool-tip-text">
+                                <p>
+                                    This section shows any goals you might have
+                                    made.
+                                </p>
+                                <p>
+                                    You can make a goal when there is a skill
+                                    you want to master but it is not unlocked
+                                    yet.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(4)"
+                                >
+                                    close
+                                </button>
+                            </div>
+                        </div>
                     </div>
                     <Goals />
                 </div>

--- a/src/components/pages/SkillsView.vue
+++ b/src/components/pages/SkillsView.vue
@@ -377,74 +377,81 @@ export default {
                             next
                         </button>
                     </div>
-                    <div
-                        v-if="showTutorialTip2"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>
-                            A sad face icon indicates that the skill has not yet
-                            been mastered.
-                        </p>
-                        <p>Every mastered skill has a happy face icon.</p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(2)"
-                        >
-                            next
-                        </button>
+                    <div v-if="showTutorialTip2" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>
+                                    A sad face icon indicates that the skill has
+                                    not yet been mastered.
+                                </p>
+                                <p>
+                                    Every mastered skill has a happy face icon.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(2)"
+                                >
+                                    next
+                                </button>
+                            </div>
+                        </div>
                     </div>
-                    <div
-                        v-else-if="showTutorialTip3"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>Some nodes feature a plus or minus sign.</p>
-                        <p>
-                            This indicates that the skill contains mini-skills
-                            that need to be mastered before you can take an
-                            assessment to prove mastery of that larger skill.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(3)"
-                        >
-                            next
-                        </button>
+                    <div v-else-if="showTutorialTip3" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>Some nodes feature a plus or minus sign.</p>
+                                <p>
+                                    This indicates that the skill contains
+                                    mini-skills that need to be mastered before
+                                    you can take an assessment to prove mastery
+                                    of that larger skill.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(3)"
+                                >
+                                    next
+                                </button>
+                            </div>
+                        </div>
                     </div>
-                    <div
-                        v-else-if="showTutorialTip4"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>
-                            If you think a skill is missing (either from the
-                            site in general or from a certain branch of the
-                            tree) you can propose its addition with the "New
-                            Skill" button
-                        </p>
-                        <p>
-                            —just make sure you run a thorough search before
-                            making your suggestion.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(4)"
-                        >
-                            next
-                        </button>
+                    <div v-else-if="showTutorialTip4" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>
+                                    If you think a skill is missing (either from
+                                    the site in general or from a certain branch
+                                    of the tree) you can propose its addition
+                                    with the "New Skill" button
+                                </p>
+                                <p>
+                                    —just make sure you run a thorough search
+                                    before making your suggestion.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(4)"
+                                >
+                                    next
+                                </button>
+                            </div>
+                        </div>
                     </div>
-                    <div
-                        v-else-if="showTutorialTip5"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>
-                            Click on a skill node to go to the page for that
-                            skill.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(5)"
-                        >
-                            close
-                        </button>
+                    <div v-else-if="showTutorialTip5" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>
+                                    Click on a skill node to go to the page for
+                                    that skill.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(5)"
+                                >
+                                    close
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <!-- Instructor Tooltips -->
@@ -458,74 +465,80 @@ export default {
                     "
                     class="info-panel me-4 mt-1 bg-light"
                 >
-                    <div
-                        v-if="showTutorialTip2"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>
-                            At the top, one can filter the skills by grade
-                            level, and search for a specific skill.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(2)"
-                        >
-                            next
-                        </button>
+                    <div v-if="showTutorialTip2" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>
+                                    At the top, one can filter the skills by
+                                    grade level, and search for a specific
+                                    skill.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(2)"
+                                >
+                                    next
+                                </button>
+                            </div>
+                        </div>
                     </div>
-                    <div
-                        v-else-if="showTutorialTip3"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>Some nodes feature a plus or minus sign.</p>
-                        <p>
-                            This indicates that the skill contains mini-skills
-                            that need to be mastered before you can take an
-                            assessment to prove mastery of that larger skill.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(3)"
-                        >
-                            next
-                        </button>
+                    <div v-else-if="showTutorialTip3" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>Some nodes feature a plus or minus sign.</p>
+                                <p>
+                                    This indicates that the skill contains
+                                    mini-skills that need to be mastered before
+                                    you can take an assessment to prove mastery
+                                    of that larger skill.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(3)"
+                                >
+                                    next
+                                </button>
+                            </div>
+                        </div>
                     </div>
-                    <div
-                        v-else-if="showTutorialTip4"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>
-                            If you think a skill is missing (either from the
-                            site in general or from a certain branch of the
-                            tree) you can propose its addition with the "New
-                            Skill" button
-                        </p>
-                        <p>
-                            —just make sure you run a thorough search before
-                            making your suggestion.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(4)"
-                        >
-                            next
-                        </button>
+                    <div v-else-if="showTutorialTip4" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>
+                                    If you think a skill is missing (either from
+                                    the site in general or from a certain branch
+                                    of the tree) you can propose its addition
+                                    with the "New Skill" button
+                                </p>
+                                <p>
+                                    —just make sure you run a thorough search
+                                    before making your suggestion.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(4)"
+                                >
+                                    next
+                                </button>
+                            </div>
+                        </div>
                     </div>
-                    <div
-                        v-else-if="showTutorialTip5"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>
-                            If locking is enabled, when a student masters a
-                            skill (by passing a quiz) the next skill will be
-                            unlocked.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(5)"
-                        >
-                            close
-                        </button>
+                    <div v-else-if="showTutorialTip5" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>
+                                    If locking is enabled, when a student
+                                    masters a skill (by passing a quiz) the next
+                                    skill will be unlocked.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(5)"
+                                >
+                                    close
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <!-- Editor Tooltips -->
@@ -538,56 +551,61 @@ export default {
                     "
                     class="info-panel me-4 mt-1 bg-light"
                 >
-                    <div
-                        v-if="showTutorialTip2"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>
-                            At the top, one can filter the skills by grade
-                            level, and search for a specific skill.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(2)"
-                        >
-                            next
-                        </button>
+                    <div v-if="showTutorialTip2" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>
+                                    At the top, one can filter the skills by
+                                    grade level, and search for a specific
+                                    skill.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(2)"
+                                >
+                                    next
+                                </button>
+                            </div>
+                        </div>
                     </div>
-                    <div
-                        v-else-if="showTutorialTip3"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>
-                            If you think a skill is missing (either from the
-                            site in general or from a certain branch of the
-                            tree) you can propose its addition with the "New
-                            Skill" button
-                        </p>
-                        <p>
-                            —just make sure you run a thorough search before
-                            making your suggestion.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(3)"
-                        >
-                            next
-                        </button>
+                    <div v-else-if="showTutorialTip3" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>
+                                    If you think a skill is missing (either from
+                                    the site in general or from a certain branch
+                                    of the tree) you can propose its addition
+                                    with the "New Skill" button
+                                </p>
+                                <p>
+                                    —just make sure you run a thorough search
+                                    before making your suggestion.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(3)"
+                                >
+                                    next
+                                </button>
+                            </div>
+                        </div>
                     </div>
-                    <div
-                        v-else-if="showTutorialTip4"
-                        class="info-text mt-1 rounded p-2"
-                    >
-                        <p>Some nodes feature a plus or minus sign.</p>
-                        <p>
-                            This indicates that the skill contains mini-skills.
-                        </p>
-                        <button
-                            class="btn primary-btn"
-                            @click="progressTutorial(4)"
-                        >
-                            close
-                        </button>
+                    <div v-else-if="showTutorialTip4" class="tool-tip-base">
+                        <div class="explain-tool-tip triangle-top-right">
+                            <div class="tool-tip-text">
+                                <p>Some nodes feature a plus or minus sign.</p>
+                                <p>
+                                    This indicates that the skill contains
+                                    mini-skills.
+                                </p>
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(4)"
+                                >
+                                    close
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/pages/TidyTreeView.vue
+++ b/src/components/pages/TidyTreeView.vue
@@ -461,24 +461,41 @@ export default {
             <!-- Tooltips -->
             <div
                 v-if="showTutorialTip6"
-                class="info-panel bg-light rounded p-2 mb-2"
+                class="tool-tip-base mt-2"
+                :style="{ maxWidth: '300px' }"
             >
-                <p>Use the search field to search for specific skills.</p>
-                <button class="btn primary-btn" @click="progressTutorial(6)">
-                    next
-                </button>
+                <div class="explain-tool-tip triangle-top-left">
+                    <div class="tool-tip-text">
+                        <p>
+                            Use the search field to search for specific skills.
+                        </p>
+                        <button
+                            class="btn primary-btn"
+                            @click="progressTutorial(6)"
+                        >
+                            next
+                        </button>
+                    </div>
+                </div>
             </div>
             <div
                 v-else-if="showTutorialTip7"
-                class="info-panel bg-light rounded p-2 mb-2 mt-2 float-right"
+                class="tool-tip-base mt-2 float-right"
             >
-                <p>
-                    Use the center button to center the skill tree,<br />
-                    and the print button to print a PDF.
-                </p>
-                <button class="btn primary-btn" @click="progressTutorial(7)">
-                    next
-                </button>
+                <div class="explain-tool-tip triangle-top-right">
+                    <div class="tool-tip-text">
+                        <p>
+                            Use the center button to center the skill tree,<br />
+                            and the print button to print a PDF.
+                        </p>
+                        <button
+                            class="btn primary-btn"
+                            @click="progressTutorial(7)"
+                        >
+                            next
+                        </button>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -503,14 +520,14 @@ export default {
     <!-- Bottom grade level truncation filters -->
     <div class="tablet-and-up-legend position-absolute bottom-legend-div">
         <!-- Tooltip -->
-        <div
-            v-if="showTutorialTip5"
-            class="info-panel bg-light rounded p-2 mb-2"
-        >
-            <p>Use the buttons below to filter the skills by level.</p>
-            <button class="btn primary-btn" @click="progressTutorial(5)">
-                next
-            </button>
+        <div v-if="showTutorialTip5" class="tool-tip-base pb-3">
+            <div class="explain-tool-tip triangle-bottom-left">
+                <div class="tool-tip-text"></div>
+                <p>Use the buttons below to filter the skills by level.</p>
+                <button class="btn primary-btn" @click="progressTutorial(5)">
+                    next
+                </button>
+            </div>
         </div>
         <!-- Grade buttons -->
         <!-- If user is logged in -->
@@ -1085,11 +1102,19 @@ export default {
             </button>
         </div>
         <!-- Tooltip -->
-        <div v-if="showTutorialTip4" class="info-panel bg-light rounded p-2">
-            Use the buttons on the left to filter the skills by subject.<br />
-            <button class="btn primary-btn" @click="progressTutorial(4)">
-                next
-            </button>
+        <div v-if="showTutorialTip4" class="tool-tip-base bg-light rounded p-2">
+            <div class="explain-tool-tip triangle-top-left">
+                <div class="tool-tip-text">
+                    Use the buttons on the left to filter the skills by
+                    subject.<br />
+                    <button
+                        class="btn primary-btn"
+                        @click="progressTutorial(4)"
+                    >
+                        next
+                    </button>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -1705,6 +1730,7 @@ export default {
 
 .float-right {
     float: right;
+    right: 120px;
 }
 
 /*
@@ -1861,9 +1887,6 @@ export default {
     top: 50%;
     transform: translateY(-50%);
     left: 3px;
-    /* For the tooltip */
-    display: flex;
-    align-items: center;
 }
 
 .left-legend-div button {
@@ -2014,6 +2037,11 @@ export default {
         gap: 15px;
     }
 
+    .tool-tip-base {
+        right: 0px;
+        top: 4px;
+    }
+
     .tablet-and-up-legend {
         display: none !important;
     }
@@ -2044,6 +2072,9 @@ export default {
     }
     .legend span {
         flex-shrink: 0;
+    }
+    .tool-tip-base {
+        top: 4px;
     }
 }
 /*---*/


### PR DESCRIPTION
In this PR, I've set the styling for the tooltips on **`App.vue`** so that we pass it down, instead of re-creating it across all components. I've added arrows to all visible tooltips for students, instructors, and editors. If I've missed anything or need to tweak the design, do let me know.