### PR TITLE
fix/changed-student-btn-for-instructors-from-firstname-to-username

### DIFF
--- a/src/components/components/UserDetails.vue
+++ b/src/components/components/UserDetails.vue
@@ -32,7 +32,7 @@ export default {
     },
     computed: {
         studentName() {
-            return `${this.$parent.user.firstName || ''}`.trim();
+            return `${this.$parent.user.username}`.trim();
         }
     },
     methods: {


### PR DESCRIPTION
In this PR I've changed it from the **`first-name`** of the student to their **`username`**.