### PR TITLE
fix/adjusted-positioning-to-right-side

### DIFF
--- a/src/components/components/forum/all-post/ForumAllPost.vue
+++ b/src/components/components/forum/all-post/ForumAllPost.vue
@@ -180,7 +180,7 @@ export default {
                 class="tool-tip-base d-flex justify-content-end"
             >
                 <div
-                    class="explain-tool-tip triangle-top-left hovering-info-panel"
+                    class="explain-tool-tip triangle-top-right hovering-info-panel"
                 >
                     <div class="tool-tip-text">
                         <p>


### PR DESCRIPTION
I changed the positioning of the tooltip arrow from left to right. Apologies for the minor mishap 