### PR TITLE
fix/added-checking-if-the-skill-id-exists

### DIFF
--- a/src/components/components/ShowSkill.vue
+++ b/src/components/components/ShowSkill.vue
@@ -491,7 +491,8 @@ export default {
                         v-else-if="
                             userDetailsStore.role == 'student' &&
                             !isMastered &&
-                            skill.type != 'domain'
+                            skill.type != 'domain' &&
+                            skill.id
                         "
                         class="btn me-1 assessment-btn secondary-btn"
                         :to="skill.id + '/assessment'"


### PR DESCRIPTION
The issue is that we need to ensure skill.id is available before allowing the "Take the Test" button to be displayed. By adding the additional condition **`&& skill.id`** to the v-else-if statement, we ensure that the button only appears after the skill ID has been properly loaded. if you think I need to re-adjust it or change something, do let me know. As on my end It goes along smoothly.