### PR TITLE
fix/moved-onboarding-process-to-hub-expanded-on-descriptive-tooltips

### DIFF
--- a/src/components/components/Login.vue
+++ b/src/components/components/Login.vue
@@ -39,7 +39,7 @@ export default {
                 .then(function (data) {
                     if (data.account == 'authorized') {
                         if (data.role == 'student') {
-                            router.push({ name: 'skill-tree' });
+                            router.push({ name: 'hub' });
                         } else if (data.role == 'instructor') {
                             router.push({ name: 'students' });
                         } else if (data.role == 'editor') {

--- a/src/components/pages/HubView.vue
+++ b/src/components/pages/HubView.vue
@@ -1,7 +1,6 @@
 <script>
 // import components.
 import LastVisitedSkills from '../components/hub-components/LastVisitedSkills.vue';
-import Goals from '../components/hub-components/Goals.vue';
 import RecommendedSkillsGenerator from '../components/hub-components/RecommendedSkillsGenerator.vue';
 // Import store.
 import { useUserDetailsStore } from '../../stores/UserDetailsStore';
@@ -30,7 +29,6 @@ export default {
     },
     components: {
         LastVisitedSkills,
-        Goals,
         RecommendedSkillsGenerator
     },
     computed: {
@@ -46,7 +44,7 @@ export default {
         if (this.sessionDetailsStore.isLoggedIn) this.checkIfTutorialComplete();
     },
     methods: {
-        // Tutorial
+        // Onboardning tutorials
         async checkIfTutorialComplete() {
             try {
                 const result = await fetch(
@@ -55,13 +53,9 @@ export default {
                 );
                 const data = await result.json();
 
-                if (data === 0 && this.userDetailsStore.role != 'student') {
+                // Check for students only
+                if (data === 0 && this.userDetailsStore.role == 'student') {
                     this.showWelcomeModal = true;
-                } else if (
-                    data === 0 &&
-                    this.userDetailsStore.role == 'student'
-                ) {
-                    this.showTutorialTip1 = true;
                 } else if (data === 1) {
                     this.isTutorialComplete = true;
                 }
@@ -78,9 +72,6 @@ export default {
                 this.showTutorialTip3 = true;
             } else if (step == 3) {
                 this.showTutorialTip3 = false;
-                this.showTutorialTip4 = true;
-            } else if (step == 4) {
-                this.showTutorialTip4 = false;
                 this.markTutorialComplete();
             }
         },
@@ -192,11 +183,14 @@ export default {
                     class="tool-tip-base"
                     :style="{ maxWidth: '300px' }"
                 >
-                    <div class="explain-tool-tip triangle-top-left">
+                    <div
+                        class="explain-tool-tip triangle-top-left hovering-info-panel"
+                    >
                         <div class="tool-tip-text">
                             <p>
-                                Type a career or skill here to get
-                                recommendations.
+                                Type a career, subject area, or specific skill
+                                here to receive personalized recommendations for
+                                your learning path.
                             </p>
                             <button
                                 class="btn primary-btn"
@@ -214,6 +208,10 @@ export default {
             <!--  Last Visited Skills / Mark Assessments -->
             <div class="col mb-2">
                 <div class="h-100">
+                    <LastVisitedSkills
+                        v-if="userDetailsStore.role == 'student'"
+                        :userId="userDetailsStore.userId"
+                    />
                     <!-- Tooltip -->
                     <div
                         v-if="
@@ -222,59 +220,25 @@ export default {
                         "
                         class="tool-tip-base mb-3"
                     >
-                        <div class="explain-tool-tip triangle-bottom-left">
+                        <div
+                            class="explain-tool-tip triangle-top-left hovering-info-panel"
+                        >
                             <div class="tool-tip-text">
                                 <p>
-                                    This section shows your the last 5 skill
-                                    pages you visited.
+                                    This section displays your five most
+                                    recently visited skill pages, allowing you
+                                    to quickly resume your learning journey
+                                    where you left off.
                                 </p>
                                 <button
                                     class="btn primary-btn"
                                     @click="progressTutorial(3)"
-                                >
-                                    next
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                    <LastVisitedSkills
-                        v-if="userDetailsStore.role == 'student'"
-                        :userId="userDetailsStore.userId"
-                    />
-                </div>
-            </div>
-            <!-- Goals / Student Suggested Questions -->
-            <div v-if="userDetailsStore.role == 'xyz'" class="col-md-6 mb-2">
-                <div class="h-100">
-                    <!-- Tooltip -->
-                    <div
-                        v-if="
-                            showTutorialTip4 &&
-                            userDetailsStore.role == 'student'
-                        "
-                        class="tool-tip-base mb-3"
-                    >
-                        <div class="explain-tool-tip triangle-bottom-left">
-                            <div class="tool-tip-text">
-                                <p>
-                                    This section shows any goals you might have
-                                    made.
-                                </p>
-                                <p>
-                                    You can make a goal when there is a skill
-                                    you want to master but it is not unlocked
-                                    yet.
-                                </p>
-                                <button
-                                    class="btn primary-btn"
-                                    @click="progressTutorial(4)"
                                 >
                                     close
                                 </button>
                             </div>
                         </div>
                     </div>
-                    <Goals />
                 </div>
             </div>
         </div>
@@ -310,7 +274,11 @@ export default {
         >
             <!-- Student -->
             <div>
-                <p>This is your hub page.</p>
+                <p>
+                    This is your hub page where you can find recommended skills,
+                    track your learning progress, and access recently visited
+                    content.
+                </p>
                 <button class="btn primary-btn" @click="progressTutorial(1)">
                     next
                 </button>
@@ -320,6 +288,17 @@ export default {
 </template>
 
 <style scoped>
+/* Tooltips */
+.hovering-info-panel {
+    position: absolute;
+    z-index: 100;
+    /* border-color: var(--primary-color);
+    border-width: 2px;
+    border-style: solid; */
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    width: fit-content;
+    margin-bottom: 0 !important; /* Remove any margin that might push content */
+}
 .info-btn {
     position: absolute;
 }

--- a/src/components/pages/TidyTreeView.vue
+++ b/src/components/pages/TidyTreeView.vue
@@ -21,7 +21,6 @@ export default {
     },
     data() {
         return {
-            showWelcomeModal: false, // Modal to ask for tutorial preference.
             searchText: '',
             lastChooseResult: '',
             showResult: false,
@@ -209,7 +208,7 @@ export default {
 
                 // Check for students only
                 if (data === 0 && this.userDetailsStore.role == 'student') {
-                    this.showWelcomeModal = true;
+                    this.startTutorial();
                 } else if (data === 1) {
                     this.isTutorialComplete = true;
                 }
@@ -321,7 +320,6 @@ export default {
             // Show the tutorial tooltips and mark tutorial as not complete
             this.showTutorialTip1 = true;
             this.isTutorialComplete = false;
-            this.showWelcomeModal = false;
             // Reset tutorial fields for the user
             await this.resetTutorialProgress();
         },
@@ -341,8 +339,6 @@ export default {
             }
         },
         async closeTutorial() {
-            // Close the welcome modal
-            this.showWelcomeModal = false;
             // Mark all tutorials as complete
             await this.markAllTutorialsComplete();
         },
@@ -1605,25 +1601,6 @@ export default {
         </div>
     </div>
 
-    <!-- Onboarding tooltip modals -->
-    <div v-if="showWelcomeModal" class="modal">
-        <div class="modal-content">
-            <h1 class="heading h3">Welcome to the Collins Institute</h1>
-            <p>Would you like to go through the tutorial?</p>
-            <p>
-                You can start or restart it anytime by clicking the "i" button
-                on any page.
-            </p>
-            <div class="d-flex justify-content-between">
-                <button class="btn red-btn mx-0" @click="closeTutorial">
-                    No
-                </button>
-                <button class="btn primary-btn mx-0" @click="startTutorial">
-                    Yes
-                </button>
-            </div>
-        </div>
-    </div>
     <!-- Tutorial -->
     <div
         v-if="

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -553,7 +553,7 @@ router.beforeEach(async (to, from, next) => {
         to.name !== 'show-skill' &&
         to.name !== 'hub'
     ) {
-        next({ name: 'skill-tree' });
+        next({ name: 'hub' });
         return;
     }
 


### PR DESCRIPTION
In this PR, I've moved the onboarding process from tidy-tree to hub, so we'll have it viewed here. I also expanded on the text for the tooltips, making it a bit more descriptive. Additionally, since it wasn't set up already (at least on my side), I've adjusted it so that the landing page for both guests and students is on /hub instead. If I need to revert anything, do let me know.