### PR TITLE
feat/changed-styling-and-kept-icon-color

### DIFF
--- a/src/components/components/ShowSkill.vue
+++ b/src/components/components/ShowSkill.vue
@@ -477,7 +477,7 @@ export default {
                             xmlns="http://www.w3.org/2000/svg"
                             viewBox="0 0 448 512"
                             width="20"
-                            class="primary-icon"
+                            fill="white"
                         >
                             <!-- !Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc. -->
                             <path
@@ -502,7 +502,7 @@ export default {
                             xmlns="http://www.w3.org/2000/svg"
                             viewBox="0 0 576 512"
                             width="22"
-                            class="primary-icon"
+                            fill="white"
                         >
                             <!-- !Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc. -->
                             <path
@@ -515,7 +515,7 @@ export default {
                             xmlns="http://www.w3.org/2000/svg"
                             viewBox="0 0 576 512"
                             width="22"
-                            class="primary-icon"
+                            fill="white"
                         >
                             <!-- !Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc. -->
                             <path
@@ -538,7 +538,7 @@ export default {
                             xmlns="http://www.w3.org/2000/svg"
                             viewBox="0 0 576 512"
                             width="22"
-                            class="primary-icon"
+                            fill="white"
                         >
                             <!-- !Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc. -->
                             <path
@@ -551,7 +551,7 @@ export default {
                             xmlns="http://www.w3.org/2000/svg"
                             viewBox="0 0 576 512"
                             width="22"
-                            class="primary-icon"
+                            fill="white"
                         >
                             <!-- !Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc. -->
                             <path
@@ -571,7 +571,7 @@ export default {
                             xmlns="http://www.w3.org/2000/svg"
                             viewBox="0 0 576 512"
                             width="22"
-                            class="primary-icon"
+                            fill="white"
                         >
                             <!-- !Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc. -->
                             <path
@@ -585,7 +585,7 @@ export default {
                             xmlns="http://www.w3.org/2000/svg"
                             viewBox="0 0 576 512"
                             width="22"
-                            class="primary-icon"
+                            fill="white"
                         >
                             <!-- !Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc. -->
                             <path
@@ -1418,7 +1418,7 @@ p {
     max-width: fit-content;
     text-wrap: nowrap;
     border-style: solid;
-    background-color: #1e7f6e;
+    background-color: #7f1e1e;
     color: white; /* Matching the text color used by both buttons */
 }
 

--- a/src/components/components/ShowSkill.vue
+++ b/src/components/components/ShowSkill.vue
@@ -471,7 +471,7 @@ export default {
                             showAncestorLink
                         "
                         :to="'/skills/' + ancestor"
-                        class="btn assessment-btn secondary-btn me-1"
+                        class="btn assessment-btn me-1"
                     >
                         <svg
                             xmlns="http://www.w3.org/2000/svg"
@@ -494,7 +494,7 @@ export default {
                             skill.type != 'domain' &&
                             skill.id
                         "
-                        class="btn me-1 assessment-btn secondary-btn"
+                        class="btn me-1 assessment-btn"
                         :to="skill.id + '/assessment'"
                     >
                         <!-- Half star icon -->
@@ -531,7 +531,7 @@ export default {
                             skill.type == 'domain'
                         "
                         @click="MakeMastered()"
-                        class="btn me-1 assessment-btn secondary-btn"
+                        class="btn me-1 assessment-btn"
                     >
                         <!-- Half star icon -->
                         <svg
@@ -563,7 +563,7 @@ export default {
                     <!-- If not logged in, go to Login page -->
                     <router-link
                         v-else-if="!sessionDetailsStore.isLoggedIn"
-                        class="btn me-1 assessment-btn secondary-btn"
+                        class="btn me-1 assessment-btn"
                         to="/login"
                     >
                         <!-- Half star icon -->
@@ -1276,8 +1276,9 @@ export default {
             </div>
             <div v-else-if="showTutorialTip5">
                 <p>
-                    The "Requirements for Mastery" and "Learning Objectives" sections explain everything
-                    one needs to learn to master the skill.
+                    The "Requirements for Mastery" and "Learning Objectives"
+                    sections explain everything one needs to learn to master the
+                    skill.
                 </p>
                 <button class="btn primary-btn" @click="progressTutorial(5)">
                     next
@@ -1410,6 +1411,15 @@ p {
     border: 3px solid var(--secondary-contrast-color);
     font-weight: 500;
     padding: 5px;
+    font-size: 16px;
+    line-height: 24px;
+    display: flex;
+    align-items: center;
+    max-width: fit-content;
+    text-wrap: nowrap;
+    border-style: solid;
+    background-color: #1e7f6e;
+    color: white; /* Matching the text color used by both buttons */
 }
 
 .info-box {


### PR DESCRIPTION
In this PR, we fix a styling conflict by removing **`secondary-btn`** class. I updated the assessment button with a **`teal background (#1e7f6e)`** to complement the existing **`.socratic-btn`** and **`.assessing-btn`** buttons while maintaining the original purple star icons for visual consistency. The white text ensures good readability (the text change is just auto-formating from prettier) . Let me know if I need to make additional changes.