### PR TITLE
feat/added-skill-tree-tab-as-optional-for-instructor

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -183,6 +183,7 @@ export default {
                         <li
                             v-if="
                                 userDetailsStore.role == 'student' ||
+                                userDetailsStore.role == 'instructor' ||
                                 userDetailsStore.role == 'editor'
                             "
                             class="nav-item"


### PR DESCRIPTION
In this PR I've added the option for instructor to view the **`skill-tree`**.  I have double-triple checked in **`TidyTreeView.vue`**, **`App.vue`** and **`TidyTree.vue`**.  To check If there's anything specific lines where It's adjusted for editors, but It doesn't seem to have them, just in **`App.vue`**. From what I can see It's working okay.