### PR TITLE
feat/added-logic-to-hide-asessor-buttons

### DIFF
--- a/src/components/components/ShowSkill.vue
+++ b/src/components/components/ShowSkill.vue
@@ -485,8 +485,12 @@ export default {
         progressTutorial(step) {
             if (step == 1) {
                 this.showTutorialTip1 = false;
-                if (!this.isMastered) this.showTutorialTip2 = true;
-                else this.showTutorialTip3 = true;
+                if (!this.isMastered) {
+                    this.showTutorialTip2 = true;
+                } else {
+                    // If skill is already mastered, skip step 2 (assessment button tooltip)
+                    this.showTutorialTip3 = true;
+                }
             } else if (step == 2) {
                 this.showTutorialTip2 = false;
                 this.showTutorialTip3 = true;
@@ -499,24 +503,25 @@ export default {
             } else if (step == 5) {
                 this.showTutorialTip5 = false;
                 this.showTutorialTip6 = true;
+                // Skip straight to AI tutor tooltip for editors/instructors
                 if (
                     this.userDetailsStore.role === 'editor' ||
                     this.userDetailsStore.role === 'instructor'
                 ) {
+                    this.showTutorialTip6 = false;
                     this.showTutorialTip7 = true;
                 }
             } else if (step == 6) {
                 this.showTutorialTip6 = false;
                 this.showTutorialTip7 = true;
-                if (
-                    this.userDetailsStore.role === 'editor' ||
-                    this.userDetailsStore.role === 'instructor'
-                ) {
-                    this.showTutorialTip7 = false;
-                }
             } else if (step == 7) {
                 this.showTutorialTip7 = false;
-                this.showTutorialTip8 = true;
+                // If skill is mastered, skip AI Tutor assessment tooltips
+                if (this.isMastered) {
+                    this.showTutorialTip10 = true;
+                } else {
+                    this.showTutorialTip8 = true;
+                }
             } else if (step == 8) {
                 this.showTutorialTip8 = false;
                 this.showTutorialTip9 = true;

--- a/src/components/components/ai-tutor/AITutor.vue
+++ b/src/components/components/ai-tutor/AITutor.vue
@@ -637,9 +637,9 @@ export default {
                     </div>
                 </div>
                 <!-- Exam Agent: assesses student -->
-                <div class="d-inline-block mt-1">
+                <div class="d-inline-block mt-1" v-if="!$parent.isMastered">
                     <button
-                        class="btn ms-1 assessing-btn fs-2 fw-bold py-1"
+                        class="btn ms-1 assessing-btn fs-2 fw-bold py-1 text-nowrap"
                         :class="{ underline: tutorType === 'assessing' }"
                         @click="handleTutorClick('assessing')"
                     >
@@ -673,14 +673,16 @@ export default {
                     </div>
                 </div>
                 <!-- Multiple Choice Assessment -->
-                <div class="d-inline-block pt-md-0 mt-1">
+                <div
+                    class="d-inline-block pt-md-0 mt-1"
+                    v-if="
+                        !$parent.isMastered &&
+                        skill.type != 'domain' &&
+                        skill.id
+                    "
+                >
                     <router-link
-                        v-if="
-                            !$parent.isMastered &&
-                            skill.type != 'domain' &&
-                            skill.id
-                        "
-                        class="btn ms-1 assessing-btn fw-bold py-1 fs-2"
+                        class="btn ms-1 assessing-btn fw-bold py-1 fs-2 text-nowrap"
                         :to="
                             userDetailsStore.userId
                                 ? skill.id + '/assessment'


### PR DESCRIPTION
In this PR I've added the logic where it hides the buttons once It's mastered, additionally made changes to the progresTutorial to skip those tutorial steps if they're mastered, so it doesn't break the code. Have a look and let me know if I need to adjust/change anything In this.