### PR TITLE
fix/register-button-text-invisible

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -651,6 +651,10 @@ p {
     text-decoration: underline;
     color: var(--primary-color);
 }
+.primary-btn.router-link-active {
+    text-decoration: underline;
+    color: var(--primary-contrast-color) !important;
+}
 
 .red-btn {
     background-color: #e24d4d;


### PR DESCRIPTION
In this PR , The problem is that the primary-btn class defines the text color as white (var(--primary-contrast-color)), but the .router-link-active class is overriding it with var(--primary-color). I've adjusted It and now It should work as intended, If I need to tweak anything let me know