### PR TITLE
fix/show-skill-buttons-alignement

### DIFF
--- a/src/components/components/ShowSkill.vue
+++ b/src/components/components/ShowSkill.vue
@@ -852,13 +852,15 @@ export default {
             </div>
             <!-- Buttons -->
             <div class="row mb-2">
-                <div class="col d-flex justify-content-between">
-                    <div
-                        class="d-flex"
-                        :class="{
-                            'justify-content-center': isMobileCheck < 576
-                        }"
-                    >
+                <div
+                    class="col d-flex"
+                    :class="{
+                        'flex-row justify-content-between':
+                            isMobileCheck >= 576,
+                        'flex-column': isMobileCheck < 576
+                    }"
+                >
+                    <div class="d-flex">
                         <!-- Edit skill btn-->
                         <router-link
                             v-if="sessionDetailsStore.isLoggedIn"
@@ -961,7 +963,7 @@ export default {
                             </div>
                         </div>
                     </div>
-                    <div class="d-flex justify-content-end">
+                    <div class="d-flex mt-2 mt-md-0">
                         <!-- Sharable URL -->
                         <button
                             @click="copyShareableURLToClipBoard"


### PR DESCRIPTION
I've had to put it in a now row, otherwise we'd have to make the buttons way too small to make sure they're all in line. Have a look how It Is and I initially thought to use justify-content-between to make sure we use the free gaps.