### PR TITLE
fix/added-missing-skip-tutorial-and-missing-tooltip

### DIFF
--- a/src/components/components/ShowSkill.vue
+++ b/src/components/components/ShowSkill.vue
@@ -583,17 +583,25 @@ export default {
                 this.showTutorialTip5 = true;
             } else if (step == 5) {
                 this.showTutorialTip5 = false;
+
+                // For editors and instructors, skip to tooltip 7 which will show at the Forum section
+                if (
+                    this.userDetailsStore.role === 'editor' ||
+                    this.userDetailsStore.role === 'instructor'
+                ) {
+                    this.showTutorialTip5 = false;
+                    this.showTutorialTip6 = true;
+                }
                 this.showTutorialTip6 = true;
-                // Skip straight to AI tutor tooltip for editors/instructors
+            } else if (step == 6) {
+                this.showTutorialTip6 = false;
                 if (
                     this.userDetailsStore.role === 'editor' ||
                     this.userDetailsStore.role === 'instructor'
                 ) {
                     this.showTutorialTip6 = false;
-                    this.showTutorialTip7 = true;
+                    this.markTutorialComplete();
                 }
-            } else if (step == 6) {
-                this.showTutorialTip6 = false;
                 this.showTutorialTip7 = true;
             } else if (step == 7) {
                 this.showTutorialTip7 = false;
@@ -1332,12 +1340,20 @@ export default {
                             <p>
                                 Here you can suggest an edit to this skill page.
                             </p>
-                            <button
-                                class="btn primary-btn"
-                                @click="progressTutorial(2)"
-                            >
-                                next
-                            </button>
+                            <div class="d-flex justify-content-between">
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(2)"
+                                >
+                                    next
+                                </button>
+                                <button
+                                    class="btn red-btn"
+                                    @click="skipTutorial"
+                                >
+                                    exit tutorial
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -1357,12 +1373,20 @@ export default {
                                 friend, or flag this page as unhelpful or
                                 incorrect.
                             </p>
-                            <button
-                                class="btn primary-btn"
-                                @click="progressTutorial(3)"
-                            >
-                                next
-                            </button>
+                            <div class="d-flex justify-content-between">
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(3)"
+                                >
+                                    next
+                                </button>
+                                <button
+                                    class="btn red-btn"
+                                    @click="skipTutorial"
+                                >
+                                    exit tutorial
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -1687,6 +1711,7 @@ export default {
                 <Forum
                     v-if="isSkillLoaded"
                     :skillId="skill.id"
+                    :showTutorialTip6="showTutorialTip6"
                     :showTutorialTip10="showTutorialTip10"
                     :userRole="userDetailsStore.role"
                     @skipTutorial="skipTutorial"
@@ -1845,18 +1870,34 @@ export default {
                     for mastering it, and take a test to demonstrate your
                     mastery.
                 </p>
-                <button class="btn primary-btn" @click="progressTutorial(1)">
-                    next
-                </button>
+                <div class="d-flex justify-content-between">
+                    <button
+                        class="btn primary-btn"
+                        @click="progressTutorial(1)"
+                    >
+                        next
+                    </button>
+                    <button class="btn red-btn" @click="skipTutorial">
+                        exit tutorial
+                    </button>
+                </div>
             </div>
             <div v-else-if="showTutorialTip4">
                 <p>
                     The "Requirements for mastery" section explains everything a
                     student needs to learn to master the skill.
                 </p>
-                <button class="btn primary-btn" @click="progressTutorial(4)">
-                    next
-                </button>
+                <div class="d-flex justify-content-between">
+                    <button
+                        class="btn primary-btn"
+                        @click="progressTutorial(4)"
+                    >
+                        next
+                    </button>
+                    <button class="btn red-btn" @click="skipTutorial">
+                        exit tutorial
+                    </button>
+                </div>
             </div>
             <div v-else-if="showTutorialTip5">
                 <p>
@@ -1864,9 +1905,8 @@ export default {
                     This" section, students can find various sites and resources
                     to learn about this topic.
                 </p>
-                <p>You can add more, vote on these, or edit them.</p>
                 <button class="btn primary-btn" @click="progressTutorial(5)">
-                    next
+                    close
                 </button>
             </div>
         </div>
@@ -1886,18 +1926,34 @@ export default {
                     This page is where students can learn about, and take a test
                     to try to master, this skill.
                 </p>
-                <button class="btn primary-btn" @click="progressTutorial(1)">
-                    next
-                </button>
+                <div class="d-flex justify-content-between">
+                    <button
+                        class="btn primary-btn"
+                        @click="progressTutorial(1)"
+                    >
+                        next
+                    </button>
+                    <button class="btn red-btn" @click="skipTutorial">
+                        exit tutorial
+                    </button>
+                </div>
             </div>
             <div v-else-if="showTutorialTip4">
                 <p>
                     The "Requirements for mastery" section explains everything a
                     student needs to learn to master the skill.
                 </p>
-                <button class="btn primary-btn" @click="progressTutorial(4)">
-                    next
-                </button>
+                <div class="d-flex justify-content-between">
+                    <button
+                        class="btn primary-btn"
+                        @click="progressTutorial(4)"
+                    >
+                        next
+                    </button>
+                    <button class="btn red-btn" @click="skipTutorial">
+                        exit tutorial
+                    </button>
+                </div>
             </div>
             <div v-else-if="showTutorialTip5">
                 <p>
@@ -1905,10 +1961,17 @@ export default {
                     This" section, students can find various sites and resources
                     to learn about this topic.
                 </p>
-                <p>You can add more and vote on these.</p>
-                <button class="btn primary-btn" @click="progressTutorial(5)">
-                    next
-                </button>
+                <div class="d-flex justify-content-between">
+                    <button
+                        class="btn primary-btn"
+                        @click="progressTutorial(5)"
+                    >
+                        next
+                    </button>
+                    <button class="btn red-btn" @click="skipTutorial">
+                        exit tutorial
+                    </button>
+                </div>
             </div>
         </div>
     </div>

--- a/src/components/components/forum/Forum.vue
+++ b/src/components/components/forum/Forum.vue
@@ -17,7 +17,7 @@ export default {
         };
     },
     emits: ['progressTutorial', 'skipTutorial'],
-    props: ['skillId', 'showTutorialTip10', 'userRole'],
+    props: ['skillId', 'showTutorialTip10', 'showTutorialTip6', 'userRole'],
     data() {
         return {
             sourcePosts: [],
@@ -299,6 +299,46 @@ export default {
                     </div>
                 </li>
             </ul>
+        </div>
+        <!-- Instructor tooltip at Forum section -->
+        <div
+            v-if="userDetailsStore.role == 'instructor' && showTutorialTip6"
+            class="tool-tip-base d-flex justify-content-end"
+        >
+            <div
+                class="explain-tool-tip triangle-bottom-right narrow-info-panel hovering-info-panel"
+            >
+                <div class="tool-tip-text">
+                    <p>You can add more sources and vote on them.</p>
+
+                    <button
+                        class="btn primary-btn"
+                        @click="$emit('progressTutorial', 6)"
+                    >
+                        close
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Editor tooltip at Forum section -->
+        <div
+            v-if="userDetailsStore.role == 'editor' && showTutorialTip6"
+            class="tool-tip-base d-flex justify-content-end"
+        >
+            <div
+                class="explain-tool-tip triangle-bottom-right narrow-info-panel hovering-info-panel"
+            >
+                <div class="tool-tip-text">
+                    <p>You can add more sources and vote on them.</p>
+                    <button
+                        class="btn primary-btn"
+                        @click="$emit('progressTutorial', 6)"
+                    >
+                        close
+                    </button>
+                </div>
+            </div>
         </div>
         <!-- ---- | Post List In This Forum | ---- -->
 


### PR DESCRIPTION
In this PR I've added two missing tooltips, and the additional skipTutorial for all tooltips for Instructors and Editors. If I should adjust the text for this tooltip, let me know.