### PR TITLE
fix/adjusted-the-tooltips-and-added-missing-skip-tutorial-buttons

### DIFF
--- a/src/components/components/ShowSkill.vue
+++ b/src/components/components/ShowSkill.vue
@@ -590,18 +590,11 @@ export default {
                     this.userDetailsStore.role === 'instructor'
                 ) {
                     this.showTutorialTip5 = false;
-                    this.showTutorialTip6 = true;
+                    this.markTutorialComplete();
                 }
                 this.showTutorialTip6 = true;
             } else if (step == 6) {
                 this.showTutorialTip6 = false;
-                if (
-                    this.userDetailsStore.role === 'editor' ||
-                    this.userDetailsStore.role === 'instructor'
-                ) {
-                    this.showTutorialTip6 = false;
-                    this.markTutorialComplete();
-                }
                 this.showTutorialTip7 = true;
             } else if (step == 7) {
                 this.showTutorialTip7 = false;
@@ -668,6 +661,7 @@ export default {
         scrollToTooltip() {
             this.$nextTick(() => {
                 if (
+                    this.userDetailsStore.role == 'student' &&
                     this.showTutorialTip6 &&
                     this.$refs.learningObjectivesSection
                 ) {
@@ -1294,12 +1288,20 @@ export default {
                                 The "Edit" button allows you to edit this skill
                                 page or its assessment.
                             </p>
-                            <button
-                                class="btn primary-btn"
-                                @click="progressTutorial(2)"
-                            >
-                                next
-                            </button>
+                            <div class="d-flex justify-content-between">
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(2)"
+                                >
+                                    next
+                                </button>
+                                <button
+                                    class="btn red-btn"
+                                    @click="skipTutorial"
+                                >
+                                    exit tutorial
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -1316,12 +1318,20 @@ export default {
                                 friend, or flag this page as unhelpful or
                                 incorrect.
                             </p>
-                            <button
-                                class="btn primary-btn"
-                                @click="progressTutorial(3)"
-                            >
-                                next
-                            </button>
+                            <div class="d-flex justify-content-between">
+                                <button
+                                    class="btn primary-btn"
+                                    @click="progressTutorial(3)"
+                                >
+                                    next
+                                </button>
+                                <button
+                                    class="btn red-btn"
+                                    @click="skipTutorial"
+                                >
+                                    exit tutorial
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -1711,7 +1721,6 @@ export default {
                 <Forum
                     v-if="isSkillLoaded"
                     :skillId="skill.id"
-                    :showTutorialTip6="showTutorialTip6"
                     :showTutorialTip10="showTutorialTip10"
                     :userRole="userDetailsStore.role"
                     @skipTutorial="skipTutorial"
@@ -1966,10 +1975,7 @@ export default {
                         class="btn primary-btn"
                         @click="progressTutorial(5)"
                     >
-                        next
-                    </button>
-                    <button class="btn red-btn" @click="skipTutorial">
-                        exit tutorial
+                        close
                     </button>
                 </div>
             </div>

--- a/src/components/components/forum/Forum.vue
+++ b/src/components/components/forum/Forum.vue
@@ -17,7 +17,7 @@ export default {
         };
     },
     emits: ['progressTutorial', 'skipTutorial'],
-    props: ['skillId', 'showTutorialTip10', 'showTutorialTip6', 'userRole'],
+    props: ['skillId', 'showTutorialTip10', 'userRole'],
     data() {
         return {
             sourcePosts: [],
@@ -300,46 +300,7 @@ export default {
                 </li>
             </ul>
         </div>
-        <!-- Instructor tooltip at Forum section -->
-        <div
-            v-if="userDetailsStore.role == 'instructor' && showTutorialTip6"
-            class="tool-tip-base d-flex justify-content-end"
-        >
-            <div
-                class="explain-tool-tip triangle-bottom-right narrow-info-panel hovering-info-panel"
-            >
-                <div class="tool-tip-text">
-                    <p>You can add more sources and vote on them.</p>
 
-                    <button
-                        class="btn primary-btn"
-                        @click="$emit('progressTutorial', 6)"
-                    >
-                        close
-                    </button>
-                </div>
-            </div>
-        </div>
-
-        <!-- Editor tooltip at Forum section -->
-        <div
-            v-if="userDetailsStore.role == 'editor' && showTutorialTip6"
-            class="tool-tip-base d-flex justify-content-end"
-        >
-            <div
-                class="explain-tool-tip triangle-bottom-right narrow-info-panel hovering-info-panel"
-            >
-                <div class="tool-tip-text">
-                    <p>You can add more sources and vote on them.</p>
-                    <button
-                        class="btn primary-btn"
-                        @click="$emit('progressTutorial', 6)"
-                    >
-                        close
-                    </button>
-                </div>
-            </div>
-        </div>
         <!-- ---- | Post List In This Forum | ---- -->
 
         <ForumResource


### PR DESCRIPTION
In this PR I've adjusted It so that it doesn't drop down to the AITutor part once we click "close", additionally added the missing "skip tutorial" buttons, now It should work as intended.