### PR TITLE
fix/adjusted-underline-to-show-up-when-clicked-instead

### DIFF
--- a/src/components/components/ai-tutor/AITutor.vue
+++ b/src/components/components/ai-tutor/AITutor.vue
@@ -753,7 +753,7 @@ export default {
                             class="btn socratic-btn ms-1 fs-2 w-100 py-2 fw-bold h-100 text-nowrap"
                             :class="{
                                 'text-decoration-underline':
-                                    tutorType === 'socratic'
+                                    mode !== 'hide' && tutorType === 'socratic'
                             }"
                             @click="handleTutorClick('socratic')"
                         >


### PR DESCRIPTION
In this PR I've simply adjusted it to be hidden until we click it, so this way the underline will show up once we click on the button.