### PR TITLE
fix/removed-typo-error

### DIFF
--- a/src/components/components/ai-tutor/AITutor.vue
+++ b/src/components/components/ai-tutor/AITutor.vue
@@ -605,7 +605,7 @@ export default {
             deep: true
         },
         mode: {
-            handlerhandler(newItem, oldItem) {
+            handler(newItem, oldItem) {
                 if (
                     newItem === 'modal' &&
                     (oldItem === 'hide' || oldItem === 'docked')


### PR DESCRIPTION
The issue was the typo **`handlerhandler`** in **`AITutor.vue`**.  I changed It to handler and It fixed it.