### PR TITLE
fix/adjusted-goals-under-link-and-fixed-styling

### DIFF
--- a/src/components/components/Goals.vue
+++ b/src/components/components/Goals.vue
@@ -50,28 +50,6 @@ export default {
 
 <template>
     <div class="row">
-        <!-- Tooltip -->
-        <div
-            v-if="showTutorialTip && userDetailsStore.role == 'student'"
-            class="tool-tip-base"
-        >
-            <div class="explain-tool-tip hovering-info-panel triangle-top-left">
-                <div class="tool-tip-text">
-                    <p>This section shows any goals you might have made.</p>
-                    <p>
-                        You can make a goal when there is a skill you want to
-                        master but it is not unlocked yet.
-                    </p>
-                    <button
-                        class="btn primary-btn"
-                        @click="handleProgressTutorial(1)"
-                    >
-                        close
-                    </button>
-                </div>
-            </div>
-        </div>
-
         <div id="goal-list">
             <router-link
                 v-for="goal in goals"
@@ -102,6 +80,27 @@ export default {
                 {{ goal.name }}
             </router-link>
         </div>
+        <!-- Tooltip -->
+        <div
+            v-if="showTutorialTip && userDetailsStore.role == 'student'"
+            class="tool-tip-base"
+        >
+            <div class="explain-tool-tip hovering-info-panel triangle-top-left">
+                <div class="tool-tip-text">
+                    <p>This section shows any goals you might have made.</p>
+                    <p>
+                        You can make a goal when there is a skill you want to
+                        master but it is not unlocked yet.
+                    </p>
+                    <button
+                        class="btn primary-btn"
+                        @click="handleProgressTutorial(1)"
+                    >
+                        close
+                    </button>
+                </div>
+            </div>
+        </div>
     </div>
 </template>
 
@@ -110,12 +109,11 @@ export default {
 .hovering-info-panel {
     position: absolute;
     z-index: 100;
-    /* border-color: var(--primary-color);
-    border-width: 2px;
-    border-style: solid; */
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    min-width: 320px; /* Set a minimum width */
     width: fit-content;
-    margin-bottom: 0 !important; /* Remove any margin that might push content */
+    max-width: 90vw; /* Make it responsive */
+    margin-bottom: 0 !important;
 }
 /* Scrollbar */
 ::-webkit-scrollbar {


### PR DESCRIPTION
I've adjusted the styling so it isn't so narrow and additionally placed it under the list since the page titles seem to have been removed (not just Goals but on other pages as well, such as Subscription).