### PR TITLE
feat/make-names-of-domain-nodes-darker

### DIFF
--- a/src/components/components/skilltrees/StudentTidyTree.vue
+++ b/src/components/components/skilltrees/StudentTidyTree.vue
@@ -318,8 +318,8 @@ export default {
                     ctx1.beginPath();
                     ctx1.strokeStyle = '#FFF';
                     ctx1.lineWidth = 4;
-                    // Changed domain text color to be lighter (previously #849cab)
-                    ctx1.fillStyle = '#aabbc5';
+                    // Changed domain text color to be darker (previously #849cab/ #aabbc5)
+                    ctx1.fillStyle = '#546673';
                     ctx1.direction = 'rtl';
                     ctx1.strokeText(
                         node.data.skill_name,

--- a/src/components/components/skilltrees/TidyTree.vue
+++ b/src/components/components/skilltrees/TidyTree.vue
@@ -1909,8 +1909,8 @@ export default {
                 ctx1.beginPath();
                 ctx1.strokeStyle = '#FFF';
                 ctx1.lineWidth = 4;
-                // Updated domain text color to be lighter gray (previously #849cab)
-                ctx1.fillStyle = isSearched ? '#ff0000' : '#aabbc5';
+                // Updated domain text color to be darker gray (previously #849cab/#aabbc5)
+                ctx1.fillStyle = isSearched ? '#ff0000' : '#546673';
                 ctx1.direction = 'ltr';
 
                 let xPosition = node.y - 140;

--- a/src/components/components/skilltrees/TidyTreeNoAccount.vue
+++ b/src/components/components/skilltrees/TidyTreeNoAccount.vue
@@ -1437,8 +1437,8 @@ export default {
                 ctx1.beginPath();
                 ctx1.strokeStyle = '#FFF';
                 ctx1.lineWidth = 4;
-                // Updated domain text color to be lighter gray
-                ctx1.fillStyle = isSearched ? '#ff0000' : '#aabbc5';
+                // Updated domain text color to be darker gray
+                ctx1.fillStyle = isSearched ? '#ff0000' : '#546673';
                 ctx1.direction = 'ltr';
 
                 let xPosition = node.y - 140;


### PR DESCRIPTION
In this PR In **`StudentTidyTree.vue`**, **`StudentTidyTreeNoAccount.vue`** and **`TidyTree.vue`** changed the color for all the domain fillStyle from **`#aabbc5`** to **`#546673`** a darker color.