### PR TITLE
fix/ai-tutor-ui-input-box-overlap

### DIFF
--- a/src/components/components/ai-tutor/AITutor.vue
+++ b/src/components/components/ai-tutor/AITutor.vue
@@ -64,8 +64,8 @@ export default {
             currentIndexAudioPlaying: null,
             isMobileCheck: window.innerWidth,
             hasTutorButtonBeenClicked: false,
-            modalTextAreaHeigh: '60px',
-            modalChatHistoryHeigh: '80%',
+            modalTextAreaHeight: '40px',
+            modalChatHistoryHeight: '80%',
             isLoading: false,
             loadingMessage: ''
         };
@@ -162,7 +162,7 @@ export default {
                 this.chatHistory = this.assessingTutorChatHistory;
             }
             // reset chat input height
-            this.modalTextAreaHeigh = '60px';
+            this.modalTextAreaHeight = '60px';
             this.mode = 'docked';
         },
         // For both tutors
@@ -601,7 +601,7 @@ export default {
         changeTextAreaHeigh() {
             const el = this.$refs.modalMessageInput;
             if (el.scrollHeight <= el.clientHeight) {
-                this.modalTextAreaHeigh = '60px';
+                this.modalTextAreaHeight = '60px';
                 return;
             }
             // Set the new height of the text area
@@ -609,16 +609,16 @@ export default {
 
             // If the text area is empty, set it to 60px
             if (this.message.length === 0) {
-                this.modalChatHistoryHeigh = '60px';
+                this.modalChatHistoryHeight = '60px';
                 return;
             }
             // If the text area is too big, set it to 400px
             if (el.scrollHeight > 400) {
-                this.modalTextAreaHeigh = '400px';
+                this.modalTextAreaHeight = '400px';
                 return;
             }
             // set the new height of the text area
-            this.modalTextAreaHeigh = newTextAreaHeigh;
+            this.modalTextAreaHeight = newTextAreaHeigh;
         },
         // Get all latex string in a message
         getLatexStrings(message) {
@@ -1467,7 +1467,7 @@ export default {
     border-radius: 15px;
     box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
         rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
-    padding-top: 15px;
+    padding-top: 10px;
     padding-bottom: 10px;
 }
 
@@ -1613,12 +1613,12 @@ export default {
     flex-direction: row;
     padding: 2px 0;
     gap: 10px;
-    background-color: white;
+    background-color: transparent;
     width: 100%;
 }
 
 .modal-chat-text-area {
-    height: v-bind(modalTextAreaHeigh);
+    height: v-bind(modalTextAreaHeight);
     min-height: 60px;
     overflow-y: auto;
     word-wrap: break-word;

--- a/src/components/components/ai-tutor/AITutor.vue
+++ b/src/components/components/ai-tutor/AITutor.vue
@@ -1404,14 +1404,10 @@ export default {
                 ></div>
             </div>
             <!-- User input (modal mode) -->
-            <div
-                :class="'modal-user-chat-div'"
-                class="mt-auto"
-                v-if="mode === 'modal'"
-            >
+            <div class="modal-user-chat-div mt-auto" v-if="mode === 'modal'">
                 <textarea
                     ref="modalMessageInput"
-                    class="chat-text-area modal-chat-text-area rounded border border-dark me-1"
+                    class="chat-text-area modal-chat-text-area rounded border border-dark"
                     v-model="message"
                     type="text"
                     @keydown.enter="handleKeyDown"
@@ -1615,6 +1611,8 @@ export default {
 .modal-user-chat-div {
     display: flex;
     flex-direction: row;
+    padding: 2px 0;
+    gap: 10px;
     background-color: white;
     width: 100%;
 }


### PR DESCRIPTION
I've adjusted It by adding a small padding and added a small gap between the input and the button (for better UX). On the devices and browsers I tested It looks good.