### PR TITLE
fix/learning-objective-audio-loading-styling-issue

### DIFF
--- a/src/components/components/ai-tutor/LearningObjectiveAITutor.vue
+++ b/src/components/components/ai-tutor/LearningObjectiveAITutor.vue
@@ -523,7 +523,6 @@ export default {
                         message.isAudioGenerating &&
                         message.role === 'assistant'
                     "
-                    class="d-flex w-100 justify-content-end"
                 >
                     <span class="speech-loader"></span>
                 </div>
@@ -613,6 +612,11 @@ export default {
 .speechButton {
     max-height: fit-content;
     color: yellow;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 /* End of Generate / Play speech */


### PR DESCRIPTION
The main Issue with this was the class that we had that stretched it out while it was loading : '**`class="d-flex w-100 justify-content-end"`**'.  I've tested it on mobile, tablet and larger screens, both on chrome and mozzila. If there are any issues do let me know, as I haven't seen any after this change.