### PR TITLE
fix/editor-theme-skill-tree-invisible

### DIFF
--- a/src/components/components/skilltrees/StudentTidyTree.vue
+++ b/src/components/components/skilltrees/StudentTidyTree.vue
@@ -348,7 +348,7 @@ export default {
                     this.context.strokeStyle = '#000';
                 else if (this.userDetailsStore.theme == 'instructor') {
                     this.context.strokeStyle = '#000';
-                } else this.context.strokeStyle = '#fff';
+                } else this.context.strokeStyle = '#000';
             }
 
             if (

--- a/src/components/components/skilltrees/TidyTree.vue
+++ b/src/components/components/skilltrees/TidyTree.vue
@@ -513,7 +513,7 @@ export default {
                     this.context.strokeStyle = '#000';
                 else if (this.userDetailsStore.theme == 'apprentice') {
                     this.context.strokeStyle = '#000';
-                } else this.context.strokeStyle = '#fff';
+                } else this.context.strokeStyle = '#000';
             }
 
             this.context.stroke();


### PR DESCRIPTION
In this PR I've adjusted from #fff to #000. This way It'll overwrite it, Ive set it for both TidyTree and StudentTidyTree.