### PR TITLE
fix/hide-file-search-referrences-tutors

### DIFF
--- a/server/utilities/openAIAssistant.js
+++ b/server/utilities/openAIAssistant.js
@@ -96,16 +96,8 @@ async function createSocraticAssistant(
     learningObjectives,
     isFileSearchSkill
 ) {
-    const assistant = await openai.beta.assistants.create({
-        name: 'Socratic Tutor',
-        instructions:
-            `You are a personal tutor teaching a ` +
-            level +
-            `student about the following subject: ` +
-            topic +
-            `, which consists of the following learning objectives:` +
-            learningObjectives +
-            `. Use the Socratic method to teach students.
+    // Build the base instruction
+    let instructions = `You are a personal tutor teaching a ${level} student about the following subject: ${topic}, which consists of the following learning objectives: ${learningObjectives}. Use the Socratic method to teach students.
 
             IMPORTANT GUIDELINES:
             - Always ask ONLY ONE QUESTION per message
@@ -114,11 +106,24 @@ async function createSocraticAssistant(
             - Wait for the student's response before asking another question
             - Focus on depth rather than breadth in your questions
 
-            Please keep all messages below 1000 characters.` +
-            isFileSearchSkill
-                ? 'Do not mention that a file has been uploaded to the file search tool.'
-                : '',
-        tools: [{ type: 'file_search' }],
+            Please keep all messages below 1000 characters.`;
+
+    // Add file search specific instructions
+    if (isFileSearchSkill) {
+        instructions += `
+            
+            IMPORTANT DOCUMENT USAGE GUIDELINES:
+            - You have access to specialized reference materials for this topic
+            - Use this information naturally in your teaching without mentioning "uploaded files" or "documents"
+            - Present the information as your knowledge of the subject
+            - Do not reference or mention that files have been uploaded or that you're accessing external documents
+            - Simply use the information to provide accurate, detailed tutoring on the topic`;
+    }
+
+    const assistant = await openai.beta.assistants.create({
+        name: 'Socratic Tutor',
+        instructions: instructions,
+        tools: isFileSearchSkill ? [{ type: 'file_search' }] : [],
         model: 'gpt-4.5-preview'
     });
 
@@ -201,6 +206,11 @@ async function socraticTutorMessage(threadId, assistantId, messageData) {
            - Make your question clear, specific, and focused
            - Wait for the student to respond before asking another question
 
+        5. DOCUMENT USAGE:
+           - If you have access to reference materials, use them naturally without mentioning "uploaded files" or "documents"
+           - Present information as your knowledge of the subject
+           - Do not reference that files have been uploaded or that you're accessing external documents
+
         Make sure to have $ delimiters before any science and math strings that can convert to Latex
         Please keep all messages below 1000 characters, and succinct.`
         });
@@ -264,16 +274,8 @@ async function createAssessingAssistant(
     learningObjectives,
     isFileSearchSkill
 ) {
-    const assistant = await openai.beta.assistants.create({
-        name: 'Assessment Tutor',
-        instructions:
-            `You are responsible for asking questions to assess whether the user understands the following subject:` +
-            topic +
-            `, which consists of the following learning objectives: ` +
-            learningObjectives +
-            `, at the following level:` +
-            level +
-            `.
+    // Build the base instruction
+    let instructions = `You are responsible for asking questions to assess whether the user understands the following subject: ${topic}, which consists of the following learning objectives: ${learningObjectives}, at the following level: ${level}.
 
             IMPORTANT ASSESSMENT GUIDELINES:
             - Always ask ONLY ONE QUESTION at a time
@@ -282,11 +284,24 @@ async function createAssessingAssistant(
             - After receiving an answer, provide feedback before asking the next question
             - Assess one concept or objective at a time
        
-            Please keep all messages below 1000 characters.` +
-            isFileSearchSkill
-                ? 'Do not mention that a file has been uploaded to the file search tool.'
-                : '',
-        tools: [],
+            Please keep all messages below 1000 characters.`;
+
+    // Add file search specific instructions
+    if (isFileSearchSkill) {
+        instructions += `
+            
+            IMPORTANT DOCUMENT USAGE GUIDELINES:
+            - You have access to specialized reference materials for this topic
+            - Use this information naturally in your assessment without mentioning "uploaded files" or "documents"
+            - Present the information as your knowledge of the subject
+            - Do not reference or mention that files have been uploaded or that you're accessing external documents
+            - Simply use the information to provide accurate, detailed assessment of the topic`;
+    }
+
+    const assistant = await openai.beta.assistants.create({
+        name: 'Assessment Tutor',
+        instructions: instructions,
+        tools: isFileSearchSkill ? [{ type: 'file_search' }] : [],
         model: 'gpt-4.5-preview'
     });
     return assistant;
@@ -369,6 +384,11 @@ async function assessingTutorMessage(threadId, assistantId, messageData) {
            - Use language appropriate for a ${messageData.skillLevel} level student
            - Aim to guide the student towards a more comprehensive understanding
 
+        4. DOCUMENT USAGE:
+           - If you have access to reference materials, use them naturally without mentioning "uploaded files" or "documents"
+           - Present information as your knowledge of the subject
+           - Do not reference that files have been uploaded or that you're accessing external documents
+
         Make sure to have $ delimiters before any science and math strings that can convert to Latex.
         Please keep all messages below 1000 characters, and succinct.`
         });
@@ -403,16 +423,16 @@ async function assessingTutorMessage(threadId, assistantId, messageData) {
 async function createLearningObjectiveAssistantAndThread(
     learningObjective,
     level,
-    neededFileSearch
+    isFileSearchSkill
 ) {
     const assistant = await createLearningObjectiveAssistant(
         level,
         learningObjective,
-        neededFileSearch
+        isFileSearchSkill
     );
 
     // only update the assistant with file search if it is in the list
-    if (neededFileSearch) {
+    if (isFileSearchSkill) {
         // Give it access to certain documents
         await openai.beta.assistants.update(assistant.id, {
             tool_resources: {
@@ -426,15 +446,13 @@ async function createLearningObjectiveAssistantAndThread(
     return result;
 }
 
-async function createLearningObjectiveAssistant(level, learningObjective) {
-    const assistant = await openai.beta.assistants.create({
-        name: 'Learning Objective Tutor',
-        instructions:
-            `You are a personal tutor teaching a ` +
-            level +
-            `student about the following subject: ` +
-            learningObjective +
-            `.
+async function createLearningObjectiveAssistant(
+    level,
+    learningObjective,
+    isFileSearchSkill
+) {
+    // Build the base instruction
+    let instructions = `You are a personal tutor teaching a ${level} student about the following subject: ${learningObjective}.
             
             IMPORTANT GUIDELINES:
             - Always ask ONLY ONE QUESTION per message
@@ -443,11 +461,24 @@ async function createLearningObjectiveAssistant(level, learningObjective) {
             - Wait for the student's response before asking a new question
             - Build questions that help the student reach a deeper understanding
             
-            Please keep all messages below 1000 characters.` +
-            isFileSearchSkill
-                ? 'Do not mention that a file has been uploaded to the file search tool.'
-                : '',
-        tools: [],
+            Please keep all messages below 1000 characters.`;
+
+    // Add file search specific instructions
+    if (isFileSearchSkill) {
+        instructions += `
+            
+            IMPORTANT DOCUMENT USAGE GUIDELINES:
+            - You have access to specialized reference materials for this topic
+            - Use this information naturally in your teaching without mentioning "uploaded files" or "documents"
+            - Present the information as your knowledge of the subject
+            - Do not reference or mention that files have been uploaded or that you're accessing external documents
+            - Simply use the information to provide accurate, detailed tutoring on the topic`;
+    }
+
+    const assistant = await openai.beta.assistants.create({
+        name: 'Learning Objective Tutor',
+        instructions: instructions,
+        tools: isFileSearchSkill ? [{ type: 'file_search' }] : [],
         model: 'gpt-4.5-preview'
     });
     return assistant;
@@ -498,82 +529,6 @@ async function getLearningObjectiveThread(userId, learningObjectiveId) {
         throw error;
     }
 }
-
-// async function requestLearningObjectiveTutoring(
-//     threadId,
-//     assistantId,
-//     messageData
-// ) {
-//     // Add a message to the thread
-//     const message = await openai.beta.threads.messages.create(threadId, {
-//         role: 'user',
-//         content: 'tutor me on this'
-//     });
-
-//     let run = await openai.beta.threads.runs.createAndPoll(threadId, {
-//         assistant_id: assistantId,
-//         instructions: `The user is at a ${messageData.skillLevel} level and age.
-//         Provide a lesson on ${messageData.learningObjective}.
-
-//         IMPORTANT GUIDELINES:
-//         - Structure your response as a clear lesson
-//         - If you include questions, ONLY ASK ONE QUESTION at the end of your message
-//         - Never ask multiple questions in a single message
-
-//         Please keep the lesson under 1000 characters.`
-//     });
-
-//     if (run.status === 'completed') {
-//         const messages = await openai.beta.threads.messages.list(threadId);
-//         const latestMessage = messages.data[0];
-
-//         // Save the user's token usage
-//         let tokenCount = run.usage.total_tokens;
-//         console.log(tokenCount);
-//         saveTokenUsage(messageData.userId, tokenCount);
-
-//         return latestMessage;
-//     } else {
-//         console.log(run.status);
-//     }
-// }
-
-// async function generateLearningObjectiveQuestion(
-//     threadId,
-//     assistantId,
-//     messageData
-// ) {
-//     // Add a message to the thread
-//     const message = await openai.beta.threads.messages.create(threadId, {
-//         role: 'user',
-//         content: 'ask me a question'
-//     });
-
-//     let run = await openai.beta.threads.runs.createAndPoll(threadId, {
-//         assistant_id: assistantId,
-//         instructions: `The user is at a ${messageData.skillLevel} level and age.
-//         Ask them ONE question about: ${messageData.learningObjective}.
-
-//         IMPORTANT:
-//         - Ask ONLY ONE clear, focused question
-//         - Never ask multiple questions in a single message
-//         - Make your question specific and targeted to assess understanding`
-//     });
-
-//     if (run.status === 'completed') {
-//         const messages = await openai.beta.threads.messages.list(threadId);
-//         const latestMessage = messages.data[0];
-
-//         // Save the user's token usage
-//         let tokenCount = run.usage.total_tokens;
-//         console.log(tokenCount);
-//         saveTokenUsage(messageData.userId, tokenCount);
-
-//         return latestMessage;
-//     } else {
-//         console.log(run.status);
-//     }
-// }
 
 // Chat streaming
 
@@ -786,8 +741,6 @@ module.exports = {
     createLearningObjectiveAssistantAndThread,
     getLearningObjectiveThread,
     saveLearningObjectiveThread,
-    //requestLearningObjectiveTutoring,
-    //generateLearningObjectiveQuestion,
     createRunStream,
     // To record user's token usage
     saveTokenUsage,

--- a/server/utilities/openAIAssistant.js
+++ b/server/utilities/openAIAssistant.js
@@ -112,12 +112,14 @@ async function createSocraticAssistant(
     if (isFileSearchSkill) {
         instructions += `
             
-            IMPORTANT DOCUMENT USAGE GUIDELINES:
-            - You have access to specialized reference materials for this topic
-            - Use this information naturally in your teaching without mentioning "uploaded files" or "documents"
-            - Present the information as your knowledge of the subject
-            - Do not reference or mention that files have been uploaded or that you're accessing external documents
-            - Simply use the information to provide accurate, detailed tutoring on the topic`;
+            CRITICAL DOCUMENT USAGE RULES - FOLLOW STRICTLY:
+            - NEVER mention "uploaded files", "documents", "materials", "files", or "uploaded" in any context
+            - NEVER reference document uploads, file searches, or external sources
+            - Present ALL information as your natural knowledge of the subject
+            - Use reference materials seamlessly without any acknowledgment of their existence
+            - If you have specialized knowledge, present it as if it's part of your training
+            - FORBIDDEN PHRASES: "uploaded", "document", "file", "material", "based on the", "according to"
+            - Act as if you are an expert who naturally knows this information`;
     }
 
     const assistant = await openai.beta.assistants.create({
@@ -206,10 +208,13 @@ async function socraticTutorMessage(threadId, assistantId, messageData) {
            - Make your question clear, specific, and focused
            - Wait for the student to respond before asking another question
 
-        5. DOCUMENT USAGE:
-           - If you have access to reference materials, use them naturally without mentioning "uploaded files" or "documents"
-           - Present information as your knowledge of the subject
-           - Do not reference that files have been uploaded or that you're accessing external documents
+        5. CRITICAL DOCUMENT USAGE RULES - FOLLOW STRICTLY:
+           - NEVER mention "uploaded files", "documents", "materials", "files", or "uploaded" in any context
+           - NEVER reference document uploads, file searches, or external sources
+           - Present ALL information as your natural knowledge of the subject
+           - Use reference materials seamlessly without any acknowledgment of their existence
+           - FORBIDDEN PHRASES: "uploaded", "document", "file", "material", "based on the", "according to"
+           - Act as if you are an expert who naturally knows this information
 
         Make sure to have $ delimiters before any science and math strings that can convert to Latex
         Please keep all messages below 1000 characters, and succinct.`
@@ -290,12 +295,14 @@ async function createAssessingAssistant(
     if (isFileSearchSkill) {
         instructions += `
             
-            IMPORTANT DOCUMENT USAGE GUIDELINES:
-            - You have access to specialized reference materials for this topic
-            - Use this information naturally in your assessment without mentioning "uploaded files" or "documents"
-            - Present the information as your knowledge of the subject
-            - Do not reference or mention that files have been uploaded or that you're accessing external documents
-            - Simply use the information to provide accurate, detailed assessment of the topic`;
+            CRITICAL DOCUMENT USAGE RULES - FOLLOW STRICTLY:
+            - NEVER mention "uploaded files", "documents", "materials", "files", or "uploaded" in any context
+            - NEVER reference document uploads, file searches, or external sources
+            - Present ALL information as your natural knowledge of the subject
+            - Use reference materials seamlessly without any acknowledgment of their existence
+            - If you have specialized knowledge, present it as if it's part of your training
+            - FORBIDDEN PHRASES: "uploaded", "document", "file", "material", "based on the", "according to"
+            - Act as if you are an expert who naturally knows this information`;
     }
 
     const assistant = await openai.beta.assistants.create({
@@ -384,10 +391,13 @@ async function assessingTutorMessage(threadId, assistantId, messageData) {
            - Use language appropriate for a ${messageData.skillLevel} level student
            - Aim to guide the student towards a more comprehensive understanding
 
-        4. DOCUMENT USAGE:
-           - If you have access to reference materials, use them naturally without mentioning "uploaded files" or "documents"
-           - Present information as your knowledge of the subject
-           - Do not reference that files have been uploaded or that you're accessing external documents
+        4. CRITICAL DOCUMENT USAGE RULES - FOLLOW STRICTLY:
+           - NEVER mention "uploaded files", "documents", "materials", "files", or "uploaded" in any context
+           - NEVER reference document uploads, file searches, or external sources
+           - Present ALL information as your natural knowledge of the subject
+           - Use reference materials seamlessly without any acknowledgment of their existence
+           - FORBIDDEN PHRASES: "uploaded", "document", "file", "material", "based on the", "according to"
+           - Act as if you are an expert who naturally knows this information
 
         Make sure to have $ delimiters before any science and math strings that can convert to Latex.
         Please keep all messages below 1000 characters, and succinct.`
@@ -467,12 +477,14 @@ async function createLearningObjectiveAssistant(
     if (isFileSearchSkill) {
         instructions += `
             
-            IMPORTANT DOCUMENT USAGE GUIDELINES:
-            - You have access to specialized reference materials for this topic
-            - Use this information naturally in your teaching without mentioning "uploaded files" or "documents"
-            - Present the information as your knowledge of the subject
-            - Do not reference or mention that files have been uploaded or that you're accessing external documents
-            - Simply use the information to provide accurate, detailed tutoring on the topic`;
+            CRITICAL DOCUMENT USAGE RULES - FOLLOW STRICTLY:
+            - NEVER mention "uploaded files", "documents", "materials", "files", or "uploaded" in any context
+            - NEVER reference document uploads, file searches, or external sources
+            - Present ALL information as your natural knowledge of the subject
+            - Use reference materials seamlessly without any acknowledgment of their existence
+            - If you have specialized knowledge, present it as if it's part of your training
+            - FORBIDDEN PHRASES: "uploaded", "document", "file", "material", "based on the", "according to"
+            - Act as if you are an expert who naturally knows this information`;
     }
 
     const assistant = await openai.beta.assistants.create({


### PR DESCRIPTION
In this PR, I've addressed the issue where the AI Tutors were incorrectly telling users about the "uploaded files". 

- I've added a **`DOCUMENT USAGE GUIDELINES`** to all assistant types, introducing them to use reference materials naturally without mentioning said files.
- I've updated the runtime instructions for consistent behaviour during conversations
- Made file search tools conditional (only enabled when it's needed)
- and fixed parameter passing in **`createLearningObjectiveAssistant`**

