### PR TITLE
fix/bug-resolved-in-AITutor-extending-space-blocking-buttons

### DIFF
--- a/src/components/components/ai-tutor/AITutor.vue
+++ b/src/components/components/ai-tutor/AITutor.vue
@@ -1303,6 +1303,11 @@ export default {
             <TutorLoadingSymbol />
         </div>
         <div
+            v-if="
+                showChat &&
+                mode !== 'hide' &&
+                (chatHistory.length > 0 || waitForAIresponse)
+            "
             class="d-flex flex-column align-items-start tutor-chatting-section"
             :class="{
                 'tutor-chatting-waiting-response-section':
@@ -1709,6 +1714,10 @@ export default {
 }
 
 .tutor-chatting-section {
+    height: auto;
+}
+
+.tutor-chatting-section.active-chat {
     height: 95%;
 }
 

--- a/src/components/components/ai-tutor/AITutor.vue
+++ b/src/components/components/ai-tutor/AITutor.vue
@@ -1717,10 +1717,6 @@ export default {
     height: auto;
 }
 
-.tutor-chatting-section.active-chat {
-    height: 95%;
-}
-
 .tutor-chatting-waiting-response-section {
     height: 94% !important;
 }


### PR DESCRIPTION
The issue was the 95% height on the section when the chat is active. Just did a basic show/hide and gave it an auto height, now the issue is gone. if I need to adjust it in any other way let me know.