### PR TITLE
fix/tutor-ui-height-issue-resolved

### DIFF
--- a/src/components/components/ai-tutor/AITutor.vue
+++ b/src/components/components/ai-tutor/AITutor.vue
@@ -1713,7 +1713,7 @@ export default {
 }
 
 .tutor-chatting-section {
-    height: auto;
+    height: 94% !important;
 }
 
 .tutor-chatting-waiting-response-section {


### PR DESCRIPTION
In this PR, the issue was the auto-on height, so that it automatically calculates how much space it needs. I've placed it at 94% as it is for the other parts within the same component. This works as intended and shows the scrollbar. If I need to adjust something, do let me know.