### PR TITLE
fix/added-missing-render-condition

### DIFF
--- a/src/components/components/ai-tutor/AITutor.vue
+++ b/src/components/components/ai-tutor/AITutor.vue
@@ -1305,7 +1305,9 @@ export default {
             v-if="
                 showChat &&
                 mode !== 'hide' &&
-                (chatHistory.length > 0 || waitForAIresponse)
+                (chatHistory.length > 0 ||
+                    waitForAIresponse ||
+                    stateOfSocket.isStreaming)
             "
             class="d-flex flex-column align-items-start tutor-chatting-section"
             :class="{


### PR DESCRIPTION
The issue was that we were missing the "stateOfSocket.isStreaming" In It, so the chat section stays visible during streaming even when there are no saved messages yet