### PR TITLE
feat/added-cohort-assessment-failed-multiple-times-report

### DIFF
--- a/src/components/pages/teacher-analytics/cohort/CohortAssessmentStatusReportView.vue
+++ b/src/components/pages/teacher-analytics/cohort/CohortAssessmentStatusReportView.vue
@@ -2,6 +2,7 @@
 import { useCohortsStore } from '../../../../stores/CohortsStore';
 import { useUserDetailsStore } from '../../../../stores/UserDetailsStore';
 import CohortPassedAssessmentsHorizontalBarChart from '../../../components/teacher-analytics/cohorts/CohortPassedAssessmentsHorizontalChart.vue';
+import FailedAssessmentsHorizontalBarChart from '../../../components/teacher-analytics/students/FailedAssessmentsHorizontalBarChart.vue';
 
 export default {
     setup() {
@@ -13,18 +14,21 @@ export default {
         };
     },
     components: {
-        CohortPassedAssessmentsHorizontalBarChart
+        CohortPassedAssessmentsHorizontalBarChart,
+        FailedAssessmentsHorizontalBarChart
     },
     data() {
         return {
             cohortId: this.$route.params.cohortId,
             cohortName: '',
-            masteredSkillQuantities: []
+            masteredSkillQuantities: [],
+            failedAssessmentQuantities: []
         };
     },
     async created() {
         if (this.cohortId != 'all-students') {
             this.getCohortMasteredAssessments();
+            this.getCohortFailedAssessments();
             if (this.cohortsStore.cohorts.length < 1) {
                 await this.cohortsStore.getCohorts(
                     this.userDetailsStore.userId
@@ -38,31 +42,98 @@ export default {
             }
         } else {
             this.getAllStudentsAssessments();
+            this.getAllStudentsFailedAssessments();
         }
     },
     methods: {
         async getCohortMasteredAssessments() {
-            fetch(`/student-analytics/mastered-skills/cohort/${this.cohortId}`)
-                .then((response) => response.json())
-                .then((data) => {
-                    this.masteredSkillQuantities = data;
-                })
-                .catch((error) => {
-                    console.error('Error fetching last visited skills:', error);
-                });
+            try {
+                const response = await fetch(
+                    `/student-analytics/mastered-skills/cohort/${this.cohortId}`
+                );
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                this.masteredSkillQuantities = Array.isArray(data) ? data : [];
+            } catch (error) {
+                console.error(
+                    'Error fetching cohort mastered assessments:',
+                    error
+                );
+                this.masteredSkillQuantities = [];
+            }
         },
+
         async getAllStudentsAssessments() {
-            fetch(
-                `/student-analytics/mastered-skills/all-students/${this.userDetailsStore.userId}`
-            )
-                .then((response) => response.json())
-                .then((data) => {
-                    this.masteredSkillQuantities = data;
-                })
-                .catch((error) => {
-                    console.error('Error fetching last visited skills:', error);
-                });
+            try {
+                const response = await fetch(
+                    `/student-analytics/mastered-skills/all-students/${this.userDetailsStore.userId}`
+                );
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                this.masteredSkillQuantities = Array.isArray(data) ? data : [];
+            } catch (error) {
+                console.error(
+                    'Error fetching all students mastered assessments:',
+                    error
+                );
+                this.masteredSkillQuantities = [];
+            }
         },
+
+        async getCohortFailedAssessments() {
+            try {
+                const response = await fetch(
+                    `/student-analytics/failed-assessments/cohort/${this.cohortId}`
+                );
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                this.failedAssessmentQuantities = Array.isArray(data)
+                    ? data
+                    : [];
+            } catch (error) {
+                console.error(
+                    'Error fetching cohort failed assessments:',
+                    error
+                );
+                this.failedAssessmentQuantities = [];
+            }
+        },
+
+        async getAllStudentsFailedAssessments() {
+            try {
+                const response = await fetch(
+                    `/student-analytics/failed-assessments/all-students/${this.userDetailsStore.userId}`
+                );
+
+                if (!response.ok) {
+                    throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const data = await response.json();
+                this.failedAssessmentQuantities = Array.isArray(data)
+                    ? data
+                    : [];
+            } catch (error) {
+                console.error(
+                    'Error fetching all students failed assessments:',
+                    error
+                );
+                this.failedAssessmentQuantities = [];
+            }
+        },
+
         assessmentDate(date) {
             let jsDate = new Date(date);
             return jsDate.toLocaleString('en-US', {
@@ -84,14 +155,22 @@ export default {
             <h1 class="heading">Assessment Status Report</h1>
             <h2 class="secondary-heading h3">{{ cohortName }}</h2>
         </span>
+
         <h2 class="secondary-heading">Passed</h2>
         <CohortPassedAssessmentsHorizontalBarChart
             v-if="masteredSkillQuantities.length > 0"
             :data="masteredSkillQuantities"
             colour="darkgreen"
         />
+
         <h2 class="secondary-heading">Attempted</h2>
+
         <h2 class="secondary-heading">Failed multiple times</h2>
+        <FailedAssessmentsHorizontalBarChart
+            v-if="failedAssessmentQuantities.length > 0"
+            :data="failedAssessmentQuantities"
+            colour="darkred"
+        />
     </div>
 </template>
 


### PR DESCRIPTION
Implemented backend endpoints **`/failed-assessments/cohort/:cohortId`** and **`/failed-assessments/all-students/:userId`** to retrieve students with multiple failed assessment attempts. Updated frontend to display this data using the existing **`FailedAssessmentsHorizontalBarChart`** component, supporting both specific cohort and "all students" views. I would also need to add If you could have a look into the backend routes just In case. I think it should work well, tested it on multiple browers and made adjustments on my local DB to reflect so i can visually see these changes.