### PR TITLE
feat/added-tutorials-for-school-admin-role

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -2035,7 +2035,9 @@ router.put(
             is_hub_tutorial_complete = 1,
             is_vertical_tree_tutorial_complete = 1,
             is_my_tree_tutorial_complete = 1 ,
-            is_collapsible_tree_tutorial_complete = 1
+            is_collapsible_tree_tutorial_complete = 1,
+            is_instructors_overview_tutorial_complete = 1,
+            is_school_report_tutorial_complete = 1
         WHERE id = ${conn.escape(req.params.userId)};`;
 
         conn.query(sqlQuery, (err) => {
@@ -2070,7 +2072,9 @@ router.put(
             is_hub_tutorial_complete = 0,
             is_vertical_tree_tutorial_complete = 0,
             is_my_tree_tutorial_complete = 0,
-            is_collapsible_tree_tutorial_complete = 0
+            is_collapsible_tree_tutorial_complete = 0,
+            is_instructors_overview_tutorial_complete = 0,
+            is_school_report_tutorial_complete = 0
         WHERE id = ${conn.escape(req.params.userId)};`;
 
         conn.query(sqlQuery, (err) => {
@@ -2298,6 +2302,51 @@ router.put(
         let sqlQuery = `
             UPDATE users
             SET is_school_report_tutorial_complete = 1
+            WHERE id = ${conn.escape(req.params.userId)};`;
+
+        conn.query(sqlQuery, (err) => {
+            try {
+                if (err) {
+                    throw err;
+                }
+                res.end();
+            } catch (err) {
+                next(err);
+            }
+        });
+    }
+);
+
+//Instructor View Page.
+router.get(
+    '/check-tutorial-progress/instructors/:userId',
+    isAuthenticated,
+    (req, res, next) => {
+        res.setHeader('Content-Type', 'application/json');
+        let sqlQuery = `SELECT is_instructors_overview_tutorial_complete
+            FROM users
+            WHERE id = ${conn.escape(req.params.userId)};`;
+
+        conn.query(sqlQuery, (err, results) => {
+            try {
+                if (err) {
+                    throw err;
+                }
+                res.json(results[0].is_instructors_overview_tutorial_complete);
+            } catch (err) {
+                next(err);
+            }
+        });
+    }
+);
+
+router.put(
+    '/mark-tutorial-complete/skill/:userId',
+    isAuthenticated,
+    (req, res, next) => {
+        let sqlQuery = `
+            UPDATE users
+            SET is_instructors_overview_tutorial_complete = 1
             WHERE id = ${conn.escape(req.params.userId)};`;
 
         conn.query(sqlQuery, (err) => {

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -671,7 +671,7 @@ router.post('/add', isAuthenticated, createUserPermission, (req, res, next) => {
                                                         req.body.avatar
                                                     );
                                                     let newUserId = data.id;
-                                                    
+
                                                     // Unlock skills here
                                                     unlockInitialSkills(
                                                         newUserId
@@ -2254,6 +2254,51 @@ router.put(
     UPDATE users
     SET is_activity_report_tutorial_complete = 1
     WHERE id = ${conn.escape(req.params.userId)};`;
+
+        conn.query(sqlQuery, (err) => {
+            try {
+                if (err) {
+                    throw err;
+                }
+                res.end();
+            } catch (err) {
+                next(err);
+            }
+        });
+    }
+);
+
+// School Report page.
+router.get(
+    '/check-tutorial-progress/school-report/:userId',
+    isAuthenticated,
+    (req, res, next) => {
+        res.setHeader('Content-Type', 'application/json');
+        let sqlQuery = `SELECT is_school_report_tutorial_complete
+            FROM users
+            WHERE id = ${conn.escape(req.params.userId)};`;
+
+        conn.query(sqlQuery, (err, results) => {
+            try {
+                if (err) {
+                    throw err;
+                }
+                res.json(results[0].is_school_report_tutorial_complete);
+            } catch (err) {
+                next(err);
+            }
+        });
+    }
+);
+
+router.put(
+    '/mark-tutorial-complete/school-report/:userId',
+    isAuthenticated,
+    (req, res, next) => {
+        let sqlQuery = `
+            UPDATE users
+            SET is_school_report_tutorial_complete = 1
+            WHERE id = ${conn.escape(req.params.userId)};`;
 
         conn.query(sqlQuery, (err) => {
             try {

--- a/src/components/components/instructors/InstructorDetails.vue
+++ b/src/components/components/instructors/InstructorDetails.vue
@@ -136,7 +136,23 @@ export default {
                 {{ this.cohortsStore.selectedCohort.name }}
             </h1>
         </div>
-        <h2 class="secondary-heading">Class Progress & Attendance</h2>
+        <div class="d-flex justify-content-between mb-2">
+            <h2 class="secondary-heading">Class Progress & Attendance</h2>
+            <button class="btn me-1" @click="$parent.restartTutorial">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 192 512"
+                    width="20"
+                    height="20"
+                    class="primary-icon"
+                >
+                    <!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc. -->
+                    <path
+                        d="M48 80a48 48 0 1 1 96 0A48 48 0 1 1 48 80zM0 224c0-17.7 14.3-32 32-32l64 0c17.7 0 32 14.3 32 32l0 224 32 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 512c-17.7 0-32-14.3-32-32s14.3-32 32-32l32 0 0-192-32 0c-17.7 0-32-14.3-32-32z"
+                    />
+                </svg>
+            </button>
+        </div>
         <div>
             <h4>Time on platform</h4>
             <CohortDurationPerDayLineChart

--- a/src/components/pages/analytics/school-admin-analytics/SchoolReportView.vue
+++ b/src/components/pages/analytics/school-admin-analytics/SchoolReportView.vue
@@ -64,11 +64,12 @@ export default {
             showTutorialTip2: false,
             showTutorialTip3: false,
             showTutorialTip4: false,
-            dataMode: 'total',
-            isLoading: true
+            dataMode: 'total'
         };
     },
     async created() {
+        // Check tutorial progress
+        await this.checkIfTutorialComplete();
         // Engagement -----------------------
         await this.getAvgTimeOnSkills();
         await this.getTenantDuration();
@@ -86,9 +87,6 @@ export default {
         await this.getAvgTokensToMasterSkills();
         await this.getTotalTokensPerSkill();
         await this.getTotalTokensPerDay();
-        // Check tutorial progress
-        await this.checkIfTutorialComplete();
-        this.isLoading = false;
     },
     methods: {
         // Tutorial methods
@@ -103,6 +101,9 @@ export default {
             } else if (data == 1) {
                 this.isTutorialComplete = true;
             }
+            console.log(data);
+            console.log(this.isTutorialComplete);
+            console.log(this.showTutorialTip1);
         },
         progressTutorial(step) {
             if (step == 1) {
@@ -449,7 +450,7 @@ export default {
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 192 512"
                     width="20"
-                    height="23"
+                    height="23"                    
                     class="primary-icon"
                 >
                     <!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc. -->
@@ -1080,6 +1081,69 @@ export default {
 </template>
 
 <style scoped>
+/* Modals */
+.modal {
+    display: block;
+    /* Hidden by default */
+    position: fixed;
+    /* Stay in place */
+    z-index: 2000;
+    /* Sit on top */
+    left: 0;
+    top: 0;
+    width: 100%;
+    /* Full width */
+    height: 100%;
+    /* Full height */
+    overflow: auto;
+    /* Enable scroll if needed */
+    background-color: rgb(0, 0, 0);
+    /* Fallback color */
+    background-color: rgba(0, 0, 0, 0.4);
+    /* Black w/ opacity */
+}
+
+/* Modal Content/Box */
+.modal-content {
+    background-color: #fefefe;
+    margin: 15% auto;
+    /* 15% from the top and centered */
+    padding: 20px;
+    border: 1px solid #888;
+    width: 520px;
+    font-size: 18px;
+    /* Could be more or less, depending on screen size */
+}
+
+/* Specific phone view css */
+@media (max-width: 576px) {
+    .modal-content {
+        margin-top: 100%;
+        width: 90%;
+    }
+}
+
+/* ************************* */
+/* Tablet Styling */
+@media (min-width: 577px) and (max-width: 1023px) {
+    .modal-content {
+        width: 70%;
+    }
+
+    .modal-btn {
+        width: fit-content;
+    }
+}
+
+/* Small devices (portrait phones) */
+@media (max-width: 480px) {
+    /* Modal Content/Box */
+    .modal-content {
+        width: 90% !important;
+        margin: auto;
+        margin-top: 30%;
+    }
+}
 /* Main Tab Styling */
 .tab-btn {
     background-color: #f8f9fa;

--- a/src/components/pages/users/InstructorsView.vue
+++ b/src/components/pages/users/InstructorsView.vue
@@ -95,26 +95,6 @@ export default {
 </script>
 
 <template>
-    <!-- Top row -->
-    <div class="container-fluid">
-        <!-- Top buttons -->
-        <div class="d-flex justify-content-between mb-2">
-            <button class="btn primary-btn me-1" @click="restartTutorial">
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 192 512"
-                    width="20"
-                    height="20"
-                    fill="white"
-                >
-                    <!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc. -->
-                    <path
-                        d="M48 80a48 48 0 1 1 96 0A48 48 0 1 1 48 80zM0 224c0-17.7 14.3-32 32-32l64 0c17.7 0 32 14.3 32 32l0 224 32 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 512c-17.7 0-32-14.3-32-32s14.3-32 32-32l32 0 0-192-32 0c-17.7 0-32-14.3-32-32z"
-                    />
-                </svg>
-            </button>
-        </div>
-    </div>
     <!-- Loading animation -->
     <div
         v-if="isLoading == true"

--- a/src/components/pages/users/InstructorsView.vue
+++ b/src/components/pages/users/InstructorsView.vue
@@ -45,6 +45,44 @@ export default {
             this.instructorsPerTenant = data;
             this.selectedInstructor = this.instructorsPerTenant[0];
         },
+        async checkIfTutorialComplete() {
+            const result = await fetch(
+                '/users/check-tutorial-progress/instructors/' +
+                    this.userDetailsStore.userId
+            );
+            const data = await result.json();
+            if (data == 0) {
+                this.isTutorialComplete = false;
+                this.showTutorialTip1 = true;
+            } else if (data == 1) {
+                this.isTutorialComplete = true;
+            }
+        },
+        progressTutorial(step) {
+            if (step == 1) {
+                this.showTutorialTip1 = false;
+                this.markTutorialComplete();
+            }
+        },
+        restartTutorial() {
+            this.showTutorialTip1 = true;
+            this.isTutorialComplete = false;
+        },
+        markTutorialComplete() {
+            let url =
+                '/users/mark-tutorial-complete/skill/' +
+                this.userDetailsStore.userId;
+            const requestOptions = {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' }
+            };
+            fetch(url, requestOptions);
+        },
+        skipTutorial() {
+            this.showTutorialTip1 = false;
+            this.isTutorialComplete = true;
+            this.markTutorialComplete();
+        },
         updateInstructorDetails(instructor) {
             this.selectedInstructor = instructor;
             this.$refs.InstructorDetails.getInstructorPercentageStudentsMasteredAtLeastOneSkill();
@@ -111,6 +149,29 @@ export default {
             >
                 <div class="row">
                     <InstructorDetails />
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- Tutorial modals for school_admin -->
+    <div
+        v-if="userDetailsStore.role == 'school_admin' && showTutorialTip1"
+        class="modal"
+    >
+        <div class="modal-content">
+            <div v-if="showTutorialTip1">
+                <p>
+                    This page provides an overview of all instructors in your
+                    school, allowing you to monitor their performance and
+                    student progress.
+                </p>
+                <div class="d-flex justify-content-between">
+                    <button
+                        class="btn primary-btn"
+                        @click="progressTutorial(1)"
+                    >
+                        close
+                    </button>
                 </div>
             </div>
         </div>
@@ -231,7 +292,6 @@ export default {
     font-size: 18px;
     /* Could be more or less, depending on screen size */
 }
-
 /* Small devices (portrait phones) */
 @media (max-width: 480px) {
     /* Modal Content/Box */


### PR DESCRIPTION
In this PR I've added the tutorials for the school admin role. It works as intended and it might seem a lot of changes in SchoolReportView.vue, but thats just due to prettify with formatting (nothing has been changed), Ive only added the tutorial tooltips under the tabs and added a route to mark these tutorials as complete, and also I've added **`is_school_report_tutorial_complete`** and **`is_instructors_overview_tutorial_complete`** in the users table, that way we'll mark it as complete or not.